### PR TITLE
Switch primary branch to `main` from `v0`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "linked": [],
   "access": "restricted",
-  "baseBranch": "v0",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -3,7 +3,7 @@ name: Changeset
 on:
   push:
     branches:
-      - 'v[0-9]+'
+      - main
 
 jobs:
   create-release-pr:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -3,7 +3,7 @@ name: Preview
 on:
   pull_request:
     branches:
-      - 'v[0-9]+'
+      - main
 
 jobs:
   publish-previews:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - 'v[0-9]+'
+      - main
 
 jobs:
   publish-releases:


### PR DESCRIPTION
## Motivation

To resolve #27 

## Approach
- Created the `main` branch and pushed. It's up to date with `v0`.
- Update base branch of changesets to `main`.
- Change the branch of github action workflows from `v[0-9]+` to `main`.

## TODOs
- Once this PR is approved, I will change the primary branch to `main` before merging.
  - Will double check to make sure `main` is on the latest `v0` commit.
- Edit the base branch of the other open PR to the new branch.