### PR TITLE
Merge branch-switch changes to `main` and not `v0`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "linked": [],
   "access": "restricted",
-  "baseBranch": "v0",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -3,7 +3,7 @@ name: Changeset
 on:
   push:
     branches:
-      - 'v[0-9]+'
+      - main
 
 jobs:
   create-release-pr:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -3,7 +3,7 @@ name: Preview
 on:
   pull_request:
     branches:
-      - 'v[0-9]+'
+      - main
 
 jobs:
   publish-previews:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - 'v[0-9]+'
+      - main
 
 jobs:
   publish-releases:


### PR DESCRIPTION
Oops, was supposed to merge #31 to `main` and not `v0`.

The changes mentioned in #31 has already been made. I updated the primary branch, branch protection rules, and updated the other PR to point to `main`.