### PR TITLE
Copy over changes from effection v2 in bigtest work

### DIFF
--- a/.changeset/strong-mails-lick.md
+++ b/.changeset/strong-mails-lick.md
@@ -1,0 +1,5 @@
+---
+"@interactors/html": minor
+---
+
+Improve build configuration

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -16,11 +16,13 @@
   "scripts": {
     "clean": "rm -rf dist *.tsbuildinfo",
     "lint": "eslint \"{src,test}/**/*.ts\"",
-    "mocha": "mocha -r ts-node/register",
+    "check:types": "tsc --noEmit",
     "test:unit": "mocha -r ts-node/register \"test/**/*.test.ts\"",
     "test:types": "dtslint types --localTs ../../node_modules/typescript/lib --expectOnly",
     "test": "yarn test:unit && yarn test:types",
-    "prepack": "tsc --build && tsc --outdir dist/esm --module es2015 && tsc --outdir dist/cjs --module commonjs"
+    "prepack": "tsc --build ./tsconfig.build.json && yarn prepack:es2015 && yarn prepack:commonjs",
+    "prepack:es2015": "tsc --project ./tsconfig.build.json --outdir dist/esm --module es2015",
+    "prepack:commonjs": "tsc --project ./tsconfig.build.json --outdir dist/cjs --module commonjs"
   },
   "dependencies": {
     "@bigtest/globals": "^0.7.6",

--- a/packages/html/tsconfig.build.json
+++ b/packages/html/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/cjs",
+    "rootDir": "./src",
+    "declarationDir": "dist"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/html/tsconfig.json
+++ b/packages/html/tsconfig.json
@@ -1,11 +1,4 @@
 {
   "extends": "../../tsconfig-base.json",
-  "compilerOptions": {
-    "outDir": "dist/cjs",
-    "rootDir": "./src",
-    "declarationDir": "dist"
-  },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "exclude": ["types/**/*.ts"],
 }

--- a/packages/html/types/extend.ts
+++ b/packages/html/types/extend.ts
@@ -46,7 +46,7 @@ HTML.extend<HTMLLinkElement>('link')
 // overriding filters and actions
 const Thing = HTML.extend('thing')
   .filters({
-    id: (element) => 4
+    id: () => 4
   })
   .actions({
     click: async (interactor, value: number) => {


### PR DESCRIPTION
The `interactor` changes in https://github.com/thefrontside/bigtest/pull/941 didn't make it over to the new `interactors` monorepo. 

Related to https://github.com/thefrontside/bigtest/pull/998