### PR TITLE
Update cypress package name in sample app

### DIFF
--- a/sample/app/app-pkg.json
+++ b/sample/app/app-pkg.json
@@ -18,7 +18,7 @@
     "@babel/core": "^7.12.10",
     "@babel/preset-env": "^7.12.11",
     "@babel/preset-react": "^7.12.10",
-    "@bigtest/cypress": "^0.1.1",
+    "@interactors/with-cypress": "^0.1.2",
     "@testing-library/react": "^11.1.0",
     "babel-jest": "^26.6.3",
     "bigtest": "0.14.4",

--- a/sample/app/package-lock.json
+++ b/sample/app/package-lock.json
@@ -1510,31 +1510,6 @@
         "websocket": "^1.0.31"
       }
     },
-    "@bigtest/cypress": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@bigtest/cypress/-/cypress-0.1.1.tgz",
-      "integrity": "sha512-nQjJLcytVY8GYuectFzACgqP34H5lDPybS0O0BVhwikhM7fzORJQ7UYjWGh8tG7qiNxWkkOMP4xiysMUluO8WQ==",
-      "requires": {
-        "@bigtest/globals": "^0.7.6",
-        "@interactors/html": "^0.31.2"
-      },
-      "dependencies": {
-        "@bigtest/globals": {
-          "version": "0.7.6",
-          "resolved": "https://registry.npmjs.org/@bigtest/globals/-/globals-0.7.6.tgz",
-          "integrity": "sha512-VEMqUGmCPskM6/YKtBEOyS0sgrIfH0zcNTd1AXTJXCSMtiI5eIe46Nq6nEebjdLeI4gJiVDflvQmgidTNHvC9w==",
-          "requires": {
-            "@bigtest/suite": "^0.11.2",
-            "effection": "^1.0.0"
-          }
-        },
-        "effection": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/effection/-/effection-1.0.0.tgz",
-          "integrity": "sha512-ITAAnuI7sJqKhjvYlnm66NHaW7zrXzqgsGsjVaaqFHYDWPN8WylVj46xASfkrtwq5wmklbzy6tvRYaj2C4rDHw=="
-        }
-      }
-    },
     "@bigtest/driver": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@bigtest/driver/-/driver-0.5.7.tgz",
@@ -1863,6 +1838,29 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/effection/-/effection-1.0.0.tgz",
           "integrity": "sha512-ITAAnuI7sJqKhjvYlnm66NHaW7zrXzqgsGsjVaaqFHYDWPN8WylVj46xASfkrtwq5wmklbzy6tvRYaj2C4rDHw=="
+        }
+      }
+    },
+    "@interactors/with-cypress": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@interactors/with-cypress/-/with-cypress-0.1.2.tgz",
+      "integrity": "sha512-d1QgStthlsDvD7Ir7jBwxVfJfd+rpeXs2rTrbxsYPa9LNkUafUEL8yV3oZM/EW1zfh0bSCG+JT8BR/NtWLp5Sw==",
+      "requires": {
+        "@bigtest/globals": "^0.7.6",
+        "@interactors/html": "^0.32.0"
+      },
+      "dependencies": {
+        "@interactors/html": {
+          "version": "0.32.0",
+          "resolved": "https://registry.npmjs.org/@interactors/html/-/html-0.32.0.tgz",
+          "integrity": "sha512-W2dQoUpjDXzvdR1Ban7HnmTkltAsEC2ukIKkc20GYXqvOcTXcBscZWunt9wDQZy8aaL7nClpYXQOVZi+CmGsmQ==",
+          "requires": {
+            "@bigtest/globals": "^0.7.6",
+            "@bigtest/performance": "^0.5.0",
+            "change-case": "^4.1.1",
+            "element-is-visible": "^1.0.0",
+            "lodash.isequal": "^4.5.0"
+          }
         }
       }
     },

--- a/sample/app/src/test/cypress.spec.js
+++ b/sample/app/src/test/cypress.spec.js
@@ -1,4 +1,4 @@
-import { Button, Heading, Link } from '@bigtest/cypress';
+import { Button, Heading, Link } from '@interactors/with-cypress';
 
 describe('Interactors with Cypress', () => {
   beforeEach(() => {

--- a/sample/app/yarn.lock
+++ b/sample/app/yarn.lock
@@ -1207,14 +1207,6 @@
     effection "^1.0.0"
     websocket "^1.0.31"
 
-"@bigtest/cypress@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@bigtest/cypress/-/cypress-0.1.1.tgz#22e83fa4cbeecad305cf95863443960d900a1d91"
-  integrity sha512-nQjJLcytVY8GYuectFzACgqP34H5lDPybS0O0BVhwikhM7fzORJQ7UYjWGh8tG7qiNxWkkOMP4xiysMUluO8WQ==
-  dependencies:
-    "@bigtest/globals" "^0.7.6"
-    "@interactors/html" "^0.31.2"
-
 "@bigtest/driver@^0.5.7":
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@bigtest/driver/-/driver-0.5.7.tgz#b28e3cae8bb33daa6fdfa0d082d82797b47fef01"
@@ -1470,6 +1462,25 @@
     change-case "^4.1.1"
     element-is-visible "^1.0.0"
     lodash.isequal "^4.5.0"
+
+"@interactors/html@^0.32.0":
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/@interactors/html/-/html-0.32.0.tgz#fcd7f84ad82d2fdfde5f20199db8c5fb7261a82d"
+  integrity sha512-W2dQoUpjDXzvdR1Ban7HnmTkltAsEC2ukIKkc20GYXqvOcTXcBscZWunt9wDQZy8aaL7nClpYXQOVZi+CmGsmQ==
+  dependencies:
+    "@bigtest/globals" "^0.7.6"
+    "@bigtest/performance" "^0.5.0"
+    change-case "^4.1.1"
+    element-is-visible "^1.0.0"
+    lodash.isequal "^4.5.0"
+
+"@interactors/with-cypress@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@interactors/with-cypress/-/with-cypress-0.1.2.tgz#16e8e9d849518395c8dfed973083beb7d1e66057"
+  integrity sha512-d1QgStthlsDvD7Ir7jBwxVfJfd+rpeXs2rTrbxsYPa9LNkUafUEL8yV3oZM/EW1zfh0bSCG+JT8BR/NtWLp5Sw==
+  dependencies:
+    "@bigtest/globals" "^0.7.6"
+    "@interactors/html" "^0.32.0"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"

--- a/sample/bin/templates/cypress.js
+++ b/sample/bin/templates/cypress.js
@@ -6,7 +6,7 @@ const cypressTemplate = ({ dependencies }) => {
         "test:cypress": "start-server-and-test 'npm run start -- -p 3000' http://localhost:3000 cypress:run",
       },
       "dependencies": {
-        "@bigtest/cypress": `${dependencies['@bigtest/cypress']}`,
+        "@interactors/with-cypress": `${dependencies['@interactors/with-cypress']}`,
         "cypress": `${dependencies['cypress']}`,
         "eslint-plugin-cypress": `${dependencies['eslint-plugin-cypress']}`,
         "start-server-and-test": `${dependencies['start-server-and-test']}`


### PR DESCRIPTION
## Motivation
Sequel to https://github.com/thefrontside/interactors/pull/35

## In the future
- Could `sample` sit inside `packages` for a more conventional monorepo setup?
- Is `interactors-sample` the right package name? `@interactors/sample`? `@interactors/sample-app`?