### PR TITLE
Remove dependency on @bigtest/performance

### DIFF
--- a/.changeset/big-plums-explode.md
+++ b/.changeset/big-plums-explode.md
@@ -1,0 +1,5 @@
+---
+"@interactors/html": patch
+---
+
+Remove @bigtest/performance polyfill

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "@bigtest/globals": "^0.7.6",
-    "@bigtest/performance": "^0.5.0",
     "change-case": "^4.1.1",
     "element-is-visible": "^1.0.0",
     "lodash.isequal": "^4.5.0"
@@ -48,7 +47,6 @@
     "ts-node": "^9.1.1"
   },
   "volta": {
-    "node": "14.17.5",
-    "yarn": "1.22.11"
+    "extends": "../../package.json"
   }
 }

--- a/packages/html/src/converge.ts
+++ b/packages/html/src/converge.ts
@@ -1,4 +1,3 @@
-import { performance } from '@bigtest/performance';
 import { bigtestGlobals } from '@bigtest/globals';
 
 function wait(ms: number) {
@@ -6,12 +5,12 @@ function wait(ms: number) {
 }
 
 export async function converge<T>(fn: () => T): Promise<T> {
-  let startTime = performance.now();
+  let startTime = window.performance.now();
   while(true) {
     try {
       return fn();
     } catch(e) {
-      let diff = performance.now() - startTime;
+      let diff = window.performance.now() - startTime;
       if(diff > bigtestGlobals.defaultInteractorTimeout) {
         throw e;
       } else {

--- a/packages/with-cypress/package.json
+++ b/packages/with-cypress/package.json
@@ -36,7 +36,6 @@
     "ts-node": "^9.1.1"
   },
   "volta": {
-    "node": "14.17.5",
-    "yarn": "1.22.11"
+    "extends": "../../package.json"
   }
 }


### PR DESCRIPTION
## Motivation
https://github.com/thefrontside/bigtest/pull/1006#issuecomment-916783304

## Approach
Remove the polyfill, since `interactors` are browser-only anyway.

## After merge
Update sample app dependencies. The dev process for that part of this repo doesn't feel great, since with its own lock files it doesn't fit in the monorepo workflows.