### PR TITLE
Set up prerelease for @interactors/material-ui

### DIFF
--- a/.changeset/kind-jobs-hang.md
+++ b/.changeset/kind-jobs-hang.md
@@ -1,0 +1,5 @@
+---
+"@interactors/material-ui": patch
+---
+
+Publish new package name for material-ui interactors

--- a/.changeset/odd-geckos-fix.md
+++ b/.changeset/odd-geckos-fix.md
@@ -1,5 +1,0 @@
----
-"@interactors/material-ui": minor
----
-
-Change package name to @interactors/material-ui

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,8 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "@interactors/material-ui": "4.0.0-alpha.2"
+  },
+  "changesets": ["kind-jobs-hang"]
+}

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -10,10 +10,12 @@ jobs:
     name: Create Changeset PR
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Install Dependencies
-      run: yarn
-    - name: Create Release Pull Request
-      uses: changesets/action@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
+      - uses: actions/checkout@v1
+      - name: Install Dependencies
+        run: yarn
+      - name: Create Release Pull Request
+        uses: changesets/action@master
+        commit: "Version packages"
+        title: "Version packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}

--- a/packages/material-ui/CHANGELOG.md
+++ b/packages/material-ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.0.0-alpha.3
+
+### Minor Changes
+
+- eee44a7: Change package name to @interactors/material-ui
+
 ## \[4.0.0-alpha.2]
 
 - Added interactor for [Button](https://material-ui.com/components/buttons/) component

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interactors/material-ui",
-  "version": "4.0.0-alpha.2",
+  "version": "4.0.0-alpha.3",
   "description": "BigTest interactors for material-ui.com components.",
   "main": "dist/cjs/index.js",
   "browser": "dist/esm/index.js",


### PR DESCRIPTION
Uses `changesets`' prerelease workflow: https://github.com/atlassian/changesets/blob/eae72367e9cb8e708a1d441770dbc70930d4e1ad/docs/prereleases.md

This could be really tricky to maintain. We probably want to move to a more standard semver ASAP.