### PR TITLE
Exit changeset pre mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,8 +1,10 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "alpha",
   "initialVersions": {
     "@interactors/material-ui": "4.0.0-alpha.2"
   },
-  "changesets": ["kind-jobs-hang"]
+  "changesets": [
+    "kind-jobs-hang"
+  ]
 }


### PR DESCRIPTION
## Motivation
https://github.com/thefrontside/interactors/pull/74 wanted to release an `alpha` of `@interactors/html`, when really we just want to keep `@interactors/material-ui` on `alpha` and release `0.32.1` of `@interactors/html`.

## Approach
The changesets `pre` workflow introduced in https://github.com/thefrontside/interactors/pull/66 is already getting in the way. It was designed to keep an entire branch on a prerelease channel, not a single package in `main`.

I recommend we just make the next release of `@interactors/material-ui` `4.0.0` and drop the `alpha`.

### Alternate Designs
- We could also move `@interactors/material-ui` work to a separate branch, but that seems pretty messy.
- Could we use `covector` here?
