### PR TITLE
Change to use `@interactors/html` in sample app

### DIFF
--- a/sample/app/app-pkg.json
+++ b/sample/app/app-pkg.json
@@ -18,6 +18,7 @@
     "@babel/core": "^7.12.10",
     "@babel/preset-env": "^7.12.11",
     "@babel/preset-react": "^7.12.10",
+    "@interactors/html": "0.32.0",
     "@interactors/with-cypress": "^0.1.2",
     "@testing-library/react": "^11.1.0",
     "babel-jest": "^26.6.3",

--- a/sample/app/app-pkg.json
+++ b/sample/app/app-pkg.json
@@ -18,7 +18,7 @@
     "@babel/core": "^7.12.10",
     "@babel/preset-env": "^7.12.11",
     "@babel/preset-react": "^7.12.10",
-    "@interactors/html": "0.32.0",
+    "@interactors/html": "^0.32.0",
     "@interactors/with-cypress": "^0.1.2",
     "@testing-library/react": "^11.1.0",
     "babel-jest": "^26.6.3",

--- a/sample/app/src/test/bigtest.test.js
+++ b/sample/app/src/test/bigtest.test.js
@@ -1,4 +1,5 @@
-import { Button, Heading, Link, Page, test } from 'bigtest';
+import { Button, Heading, Link, Page } from '@interactors/html';
+import { test } from 'bigtest';
 
 export default test('Interactors with BigTest')
   .step(Page.visit('/'))

--- a/sample/app/src/test/jest.test.js
+++ b/sample/app/src/test/jest.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import App from '../App';
-import { Button, Heading, Link } from 'bigtest';
+import { Button, Heading, Link } from '@interactors/html';
 
 describe('Interactor with Jest', () => {
   beforeEach(() => {

--- a/sample/bin/templates/base.js
+++ b/sample/bin/templates/base.js
@@ -20,6 +20,7 @@ const baseTemplate = ({ dependencies }) => {
         "typescript": `${dependencies.typescript}`,
         "eslint": `${dependencies.eslint}`,
         "@babel/core": `${dependencies['@babel/core']}`,
+        "@interactors/html": `${dependencies['@interactors/html']}`,
       },
       "volta": {
         "node": "14.17.5",
@@ -32,7 +33,7 @@ const baseTemplate = ({ dependencies }) => {
       'README.md',
       'src'
     ]
-  }
+  };
 };
 
 module.exports = {

--- a/sample/bin/templates/jest.js
+++ b/sample/bin/templates/jest.js
@@ -9,7 +9,6 @@ const jestTemplate = ({ dependencies, browserslist, babel, jest }) => {
         "@babel/preset-react": `${dependencies['@babel/preset-react']}`,
         "@testing-library/react": `${dependencies['@testing-library/react']}`,
         "babel-jest": `${dependencies['babel-jest']}`,
-        "bigtest":`${dependencies['bigtest']}`,
         "jest": `${dependencies['jest']}`,
         "jest-css-modules-transform": `${dependencies['jest-css-modules-transform']}`,
         "react-test-renderer": `${dependencies['react-test-renderer']}`,
@@ -20,7 +19,7 @@ const jestTemplate = ({ dependencies, browserslist, babel, jest }) => {
       jest
     },
     files: []
-  }
+  };
 };
 
 module.exports = {

--- a/sample/package.json
+++ b/sample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interactors-sample",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Interactors Sample App",
   "repository": "https://github.com/thefrontside/interactors.git",
   "author": "Frontside Engineering <engineering@frontside.com>",


### PR DESCRIPTION
## Motivation

I ran `interactors-sample` and cypress tests failed. Then I realized that Jest and BigTest are not using `@interactors/html`.

## Approach

Change to use `@interactors/html`

## TODO

How do I test this?
