### PR TITLE
Fix exists() example

### DIFF
--- a/website/docs/4-assertions.md
+++ b/website/docs/4-assertions.md
@@ -49,7 +49,7 @@ TextField({ id: 'username-id' }).has({ visibility: true });
 Use `exists` when you expect that the interactor will find multiple results. This assertion will still pass even if there are multiple `TextField`s found.
 
 ```js
-TextField().exists({ placeholder: 'USERNAME' });
+TextField({ placeholder: 'USERNAME' }).exists();
 ```
 
 ### Using `absent()` for non-existent results


### PR DESCRIPTION
The `exists()` assertion method doesn't take an argument. 

Did I spend 5 minutes running `git blame` to figure out who it was? Maybe. But still I should've caught it in the many times I made other changes to this page. 🤦 