### PR TITLE
fix cypress > 8.2 error where cypress tries reassing error name

### DIFF
--- a/packages/html/src/errors.ts
+++ b/packages/html/src/errors.ts
@@ -1,15 +1,15 @@
 export class NoSuchElementError extends Error {
-  get name(): string { return "NoSuchElementError" }
+  name = "NoSuchElementError";
 }
 
 export class AmbiguousElementError extends Error {
-  get name(): string { return "AmbiguousElementError" }
+  name = "AmbiguousElementError";
 }
 
 export class NotAbsentError extends Error {
-  get name(): string { return "NotAbsentError" }
+  name = "NotAbsentError";
 }
 
 export class FilterNotMatchingError extends Error {
-  get name(): string { return "FilterNotMatchingError" }
+  name = "FilterNotMatchingError";
 }


### PR DESCRIPTION
## Motivation

Starting from Cypress 8.3 when a test fails Cypress outputs the `TypeError: Cannot set property name of [object Object] which has only a getter` it happens because Cypress is trying to reassign the error name https://github.com/cypress-io/cypress/blob/853a6f5a332433971e451290b3aa961139d40793/packages/driver/src/cypress/command_queue.ts#L348 and we use custom errors with the read-only name property for interactors.
More details [here](https://discord.com/channels/700803887132704931/783795154967330857/887939135606784001)

## Approach
I made the PR for Cypress https://github.com/cypress-io/cypress/pull/18259 and use the plain property for our custom error instead of getters

