### PR TITLE
Ignore node version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ yarn-error.log
 /packages/*/dist
 /packages/*/docs
 *.tsbuildinfo
+.node-version
 
 # Local Netlify folder
 .netlify


### PR DESCRIPTION
Since I'm using nodenv, it puts a .node-version file into the root directory. We probably don't want to check in this file, so let's ignore it.