### PR TITLE
add globals object for interactors

### DIFF
--- a/.changeset/global-document.md
+++ b/.changeset/global-document.md
@@ -1,0 +1,7 @@
+---
+"@interactors/html": patch
+"@interactors/material-ui": patch
+"@interactors/with-cypress": patch
+---
+
+Allow set document resolver for interactors and decouple it from `@bigtest/globals`

--- a/packages/html/src/constructor.ts
+++ b/packages/html/src/constructor.ts
@@ -25,6 +25,7 @@ import { Match } from './match';
 import { NoSuchElementError, NotAbsentError, AmbiguousElementError } from './errors';
 import { isMatcher } from './matcher';
 import { matching } from './matchers/matching';
+import { globals } from './globals';
 
 const defaultLocator: LocatorFn<Element> = (element) => element.textContent || "";
 const defaultSelector = 'div';
@@ -129,7 +130,7 @@ function getLookupFilterForAssertion<E extends Element, F extends Filters<E>>(fi
 }
 
 export function unsafeSyncResolveParent(options: InteractorOptions<any, any, any>): Element {
-  return options.ancestors.reduce(resolveUnique, bigtestGlobals.document.documentElement);
+  return options.ancestors.reduce(resolveUnique, globals.document.documentElement);
 }
 
 export function unsafeSyncResolveUnique<E extends Element>(options: InteractorOptions<E, any, any>): E {

--- a/packages/html/src/globals.ts
+++ b/packages/html/src/globals.ts
@@ -1,0 +1,30 @@
+import { bigtestGlobals } from "@bigtest/globals";
+
+interface Globals {
+  documentResolver: () => Document;
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace, @typescript-eslint/prefer-namespace-keyword
+  module globalThis {
+    // eslint-disable-next-line prefer-let/prefer-let, no-var
+    var __interactors: Globals;
+  }
+}
+
+if (!globalThis.__interactors) {
+  globalThis.__interactors = {
+    // TODO Replace it to use `globalThis.document` after we start using `setDocumentResolver` in bigtest
+    documentResolver: () => bigtestGlobals.document,
+  };
+}
+
+export const globals = {
+  get document(): Document {
+    return globalThis.__interactors.documentResolver();
+  },
+};
+
+export function setDocumentResolver(resolver: () => Document): void {
+  globalThis.__interactors.documentResolver = resolver;
+}

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -29,3 +29,4 @@ export { or } from './matchers/or';
 export { not } from './matchers/not';
 export { some } from './matchers/some';
 export { every } from './matchers/every';
+export * from './globals'

--- a/packages/html/test/fill-in.test.ts
+++ b/packages/html/test/fill-in.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'mocha';
 import { TextField, Heading } from '../src/index';
 import { dom } from './helpers';
-import { bigtestGlobals } from '@bigtest/globals';
+import { globals } from '../src/globals';
 
 describe('fillIn', () => {
   it('triggers a change event', async () => {
@@ -18,7 +18,7 @@ describe('fillIn', () => {
       </script>
     `);
 
-    bigtestGlobals.document.getElementById('nameField');
+    globals.document.getElementById('nameField');
     await TextField('Name').fillIn('changed');
     await Heading('success changed').exists();
   });
@@ -194,7 +194,7 @@ describe('fillIn', () => {
           target.textContent = 'success ' + event.target.value;
         });
       </script>`);
-    let input = bigtestGlobals.document.getElementById('nameField');
+    let input = globals.document.getElementById('nameField');
 
     // monkey patch input.value to effectively disable setting it javascript.
     Object.defineProperty(input, 'value', {

--- a/packages/html/test/helpers.ts
+++ b/packages/html/test/helpers.ts
@@ -1,13 +1,14 @@
-import { beforeEach } from 'mocha';
-import { bigtestGlobals } from '@bigtest/globals';
-import { DOMWindow, JSDOM } from 'jsdom';
+import { beforeEach } from "mocha";
+import { bigtestGlobals } from "@bigtest/globals";
+import { DOMWindow, JSDOM } from "jsdom";
+import { setDocumentResolver } from "../src/globals";
 
 let jsdom: JSDOM;
 
 export function dom(html: string): DOMWindow {
   jsdom = new JSDOM(`<!doctype html><html><body>${html}</body></html>`, { runScripts: "dangerously" });
 
-  bigtestGlobals.document = jsdom.window.document;
+  setDocumentResolver(() => jsdom.window.document);
 
   return jsdom.window;
 }

--- a/packages/html/test/page.test.ts
+++ b/packages/html/test/page.test.ts
@@ -8,7 +8,7 @@ import { JSDOM, ResourceLoader } from 'jsdom';
 
 import { dom } from './helpers';
 
-import { Page, read } from '../src/index';
+import { Page, read, setDocumentResolver } from '../src';
 
 describe('@interactors/html', function() {
   describe('Page', () => {
@@ -40,6 +40,7 @@ describe('@interactors/html', function() {
         let resources = new ResourceLoader({ proxy: "http://localhost:27000" });
         jsdom = new JSDOM(`<!doctype html><html><body><iframe/></body></html>`, { resources });
         bigtestGlobals.testFrame = jsdom.window.document.querySelector('iframe') as HTMLIFrameElement;
+        setDocumentResolver(() => bigtestGlobals.testFrame?.contentDocument as Document);
         bigtestGlobals.appUrl = 'http://example.com';
       });
 

--- a/packages/material-ui/src/helpers.ts
+++ b/packages/material-ui/src/helpers.ts
@@ -1,5 +1,4 @@
-import { bigtestGlobals } from "@bigtest/globals";
-import { Interactor } from "@interactors/html";
+import { Interactor, globals } from "@interactors/html";
 
 type HTMLTypes<T> = T extends `HTML${infer C}Element` ? C : never;
 
@@ -9,7 +8,7 @@ export function isHTMLElement<T extends HTMLElementTypes = "">(
   element: unknown | null | undefined,
   type: T = "" as T
 ): element is InstanceType<typeof window[`HTML${T}Element`]> {
-  let { defaultView } = bigtestGlobals.document;
+  let { defaultView } = globals.document;
   let Constructor = (defaultView as unknown as Record<string, unknown>)?.[`HTML${type}Element`];
   return typeof Constructor == "function" && element instanceof Constructor;
 }

--- a/packages/with-cypress/src/cypress.ts
+++ b/packages/with-cypress/src/cypress.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 /// <reference types="cypress" />
 import { bigtestGlobals, RunnerState } from '@bigtest/globals';
-import { Interaction, isInteraction, ReadonlyInteraction } from '@interactors/html';
+import { Interaction, isInteraction, ReadonlyInteraction, setDocumentResolver } from '@interactors/html';
 
 declare global {
   namespace Cypress {
@@ -12,9 +12,7 @@ declare global {
   }
 }
 
-Object.defineProperty(bigtestGlobals, 'document', {
-  get: () => cy.$$('body')[0].ownerDocument
-});
+setDocumentResolver(() => cy.$$('body')[0].ownerDocument);
 
 function interact(
   interaction: Interaction<void> | ReadonlyInteraction<void>,


### PR DESCRIPTION
## Motivation

Fix #92 

## Approach

Add `setDocumentResolver` for HTML interactors package and decouple from bigtest globals document field
