### PR TITLE
wrap bigtest globals to interactors' globals object

### DIFF
--- a/.changeset/decouple-bigtest.md
+++ b/.changeset/decouple-bigtest.md
@@ -1,0 +1,6 @@
+---
+"@interactors/html": patch
+"@interactors/with-cypress": patch
+---
+
+Wrap `@bigtest/globals` to interactors' globals object as the first step of decoupling interactors from using `@bigtest/globals`

--- a/packages/html/src/constructor.ts
+++ b/packages/html/src/constructor.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { bigtestGlobals } from '@bigtest/globals';
 import { converge } from './converge';
 import { makeBuilder } from './builder';
 import {
@@ -150,7 +149,7 @@ export function instantiateBaseInteractor<E extends Element, F extends Filters<E
 
     perform<T>(fn: (element: E) => T): Interaction<T> {
       return interaction(`${description(options)} performs`, async () => {
-        if(bigtestGlobals.runnerState === 'assertion') {
+        if(globals.runnerState === 'assertion') {
           throw new Error(`tried to run perform on ${this.description} in an assertion, perform should only be run in steps`);
         }
         return await converge(() => fn(resolver(options)));
@@ -191,7 +190,7 @@ export function instantiateBaseInteractor<E extends Element, F extends Filters<E
           actionDescription += ` with ` + args.map((a) => JSON.stringify(a)).join(', ');
         }
         return interaction(`${actionDescription} on ${this.description}`, async () => {
-          if(bigtestGlobals.runnerState === 'assertion') {
+          if(globals.runnerState === 'assertion') {
             throw new Error(`tried to ${actionDescription} on ${this.description} in an assertion, actions should only be performed in steps`);
           }
           return action(this, ...args);

--- a/packages/html/src/converge.ts
+++ b/packages/html/src/converge.ts
@@ -1,5 +1,5 @@
 import { performance } from 'performance-api';
-import { bigtestGlobals } from '@bigtest/globals';
+import { globals } from './globals'
 
 function wait(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -12,7 +12,7 @@ export async function converge<T>(fn: () => T): Promise<T> {
       return fn();
     } catch(e) {
       let diff = performance.now() - startTime;
-      if(diff > bigtestGlobals.defaultInteractorTimeout) {
+      if(diff > globals.interactorTimeout) {
         throw e;
       } else {
         await wait(1);

--- a/packages/html/src/globals.ts
+++ b/packages/html/src/globals.ts
@@ -1,7 +1,15 @@
 import { bigtestGlobals } from "@bigtest/globals";
 
+export type RunnerState = "pending" | "step" | "assertion";
+
 interface Globals {
-  documentResolver: () => Document;
+  document: Document;
+  runnerState: RunnerState;
+  appUrl?: string;
+  interactorTimeout: number;
+  testFrame?: HTMLIFrameElement;
+  appTimeout: number;
+  reset: () => void;
 }
 
 declare global {
@@ -13,18 +21,80 @@ declare global {
 }
 
 if (!globalThis.__interactors) {
-  globalThis.__interactors = {
-    // TODO Replace it to use `globalThis.document` after we start using `setDocumentResolver` in bigtest
-    documentResolver: () => bigtestGlobals.document,
-  };
+  Object.defineProperty(globalThis, "__interactors", {
+    value: Object.defineProperties(
+      {},
+      {
+        document: {
+          get() {
+            // TODO Replace it to use `globalThis.document` after we start using `setDocumentResolver` in bigtest
+            return bigtestGlobals.document;
+          },
+          enumerable: true,
+          configurable: true,
+        },
+        runnerState: {
+          get(): RunnerState {
+            return bigtestGlobals.runnerState || "pending";
+          },
+          set(state: RunnerState) {
+            bigtestGlobals.runnerState = state;
+          },
+          enumerable: true,
+        },
+        appUrl: {
+          get(): string | undefined {
+            return bigtestGlobals.appUrl;
+          },
+          set(url: string | undefined) {
+            bigtestGlobals.appUrl = url;
+          },
+          enumerable: true,
+        },
+        interactorTimeout: {
+          get(): number {
+            return bigtestGlobals.defaultInteractorTimeout;
+          },
+          set(timeout: number) {
+            bigtestGlobals.defaultInteractorTimeout = timeout;
+          },
+          enumerable: true,
+        },
+        testFrame: {
+          get(): HTMLIFrameElement | undefined {
+            return bigtestGlobals.testFrame;
+          },
+          set(frame: HTMLIFrameElement | undefined) {
+            bigtestGlobals.testFrame = frame;
+          },
+          enumerable: true,
+        },
+        appTimeout: {
+          get(): number {
+            return bigtestGlobals.defaultAppTimeout;
+          },
+          set(timeout: number) {
+            bigtestGlobals.defaultAppTimeout = timeout;
+          },
+          enumerable: true,
+        },
+        reset: {
+          value() {
+            bigtestGlobals.reset();
+          },
+          enumerable: true,
+        },
+      }
+    ),
+  });
 }
 
-export const globals = {
-  get document(): Document {
-    return globalThis.__interactors.documentResolver();
-  },
-};
+export const globals = globalThis.__interactors;
 
 export function setDocumentResolver(resolver: () => Document): void {
-  globalThis.__interactors.documentResolver = resolver;
+  Object.defineProperty(globalThis.__interactors, "document", {
+    get: resolver,
+    enumerable: true,
+    configurable: true,
+  });
 }

--- a/packages/html/src/read.ts
+++ b/packages/html/src/read.ts
@@ -1,13 +1,13 @@
-import { bigtestGlobals } from "@bigtest/globals";
 import { converge } from "./converge";
 import { interaction } from "./interaction";
 import { unsafeSyncResolveUnique } from './constructor'
 import { EmptyObject, FilterReturn, Interactor } from "./specification";
+import { globals } from "./globals";
 
 export const read = <E extends Element, F extends EmptyObject>(interactor: Interactor<E, F>, field: keyof F): Promise<FilterReturn<F>> => {
   let filter = interactor.options.specification.filters?.[field]
   return interaction(`get ${field} from ${interactor.description}`, async () => {
-    if(bigtestGlobals.runnerState === 'assertion') {
+    if(globals.runnerState === 'assertion') {
       throw new Error(`tried to get ${field} from ${interactor.description} in an assertion, getters should only be used in steps`);
     }
     let filterFn = typeof(filter) === 'function' ? filter : filter.apply

--- a/packages/html/test/create-interactor.test.ts
+++ b/packages/html/test/create-interactor.test.ts
@@ -1,9 +1,8 @@
 import { describe, it } from 'mocha';
 import expect from 'expect';
 import { dom } from './helpers';
-import { bigtestGlobals } from '@bigtest/globals';
 
-import { createInteractor, read } from '../src/index';
+import { createInteractor, read, globals } from '../src';
 
 const Link = createInteractor<HTMLLinkElement>('link')
   .selector('a')
@@ -427,7 +426,7 @@ describe('@interactors/html', () => {
         <p><a href="/foo">Foo</a></p>
       `);
 
-      bigtestGlobals.runnerState = 'assertion';
+      globals.runnerState = 'assertion';
 
       await expect(Link('Foo').click()).rejects.toHaveProperty('message',
         'tried to click on link "Foo" in an assertion, actions should only be performed in steps'

--- a/packages/html/test/helpers.ts
+++ b/packages/html/test/helpers.ts
@@ -1,7 +1,6 @@
 import { beforeEach } from "mocha";
-import { bigtestGlobals } from "@bigtest/globals";
 import { DOMWindow, JSDOM } from "jsdom";
-import { setDocumentResolver } from "../src/globals";
+import { globals, setDocumentResolver } from "../src/globals";
 
 let jsdom: JSDOM;
 
@@ -14,8 +13,8 @@ export function dom(html: string): DOMWindow {
 }
 
 beforeEach(() => {
-  bigtestGlobals.reset();
-  bigtestGlobals.defaultInteractorTimeout = 20;
+  globals.reset();
+  globals.interactorTimeout = 20;
 });
 
 afterEach(() => {

--- a/packages/html/test/interactor.test.ts
+++ b/packages/html/test/interactor.test.ts
@@ -1,9 +1,8 @@
 import { describe, it } from 'mocha';
 import expect from 'expect';
 import { dom } from './helpers';
-import { bigtestGlobals } from '@bigtest/globals';
 
-import { createInteractor, Link, Heading } from '../src/index';
+import { createInteractor, Link, Heading, globals } from '../src';
 
 const MainNav = createInteractor('main nav')({
   selector: 'nav'
@@ -75,7 +74,7 @@ describe('@interactors/html', () => {
         <p><a href="/foo">Foo</a></p>
       `);
 
-      bigtestGlobals.runnerState = 'assertion';
+      globals.runnerState = 'assertion';
 
       await expect(Link('Foo').perform((e) => e.click())).rejects.toHaveProperty('message',
         'tried to run perform on link "Foo" in an assertion, perform should only be run in steps'
@@ -130,7 +129,7 @@ describe('@interactors/html', () => {
         <a data-foo="foo" href="/foobar">Foo Bar</a>
       `);
 
-      bigtestGlobals.runnerState = 'assertion';
+      globals.runnerState = 'assertion';
 
       await Link('Foo Bar').assert((e) => expect(e.dataset.foo).toEqual('foo'));
     });

--- a/packages/html/test/page.test.ts
+++ b/packages/html/test/page.test.ts
@@ -3,12 +3,11 @@ import expect from 'expect';
 import express from 'express';
 import { Server } from 'http';
 
-import { bigtestGlobals } from '@bigtest/globals';
 import { JSDOM, ResourceLoader } from 'jsdom';
 
 import { dom } from './helpers';
 
-import { Page, read, setDocumentResolver } from '../src';
+import { globals, Page, read, setDocumentResolver } from '../src';
 
 describe('@interactors/html', function() {
   describe('Page', () => {
@@ -17,7 +16,7 @@ describe('@interactors/html', function() {
       let server: Server;
 
       beforeEach(async () => {
-        bigtestGlobals.reset();
+        globals.reset();
 
         let app = express();
 
@@ -39,9 +38,9 @@ describe('@interactors/html', function() {
 
         let resources = new ResourceLoader({ proxy: "http://localhost:27000" });
         jsdom = new JSDOM(`<!doctype html><html><body><iframe/></body></html>`, { resources });
-        bigtestGlobals.testFrame = jsdom.window.document.querySelector('iframe') as HTMLIFrameElement;
-        setDocumentResolver(() => bigtestGlobals.testFrame?.contentDocument as Document);
-        bigtestGlobals.appUrl = 'http://example.com';
+        globals.testFrame = jsdom.window.document.querySelector('iframe') as HTMLIFrameElement;
+        setDocumentResolver(() => globals.testFrame?.contentDocument as Document);
+        globals.appUrl = 'http://example.com';
       });
 
       afterEach(() => {
@@ -71,12 +70,12 @@ describe('@interactors/html', function() {
       });
 
       it('throws an error if app url is not defined', async () => {
-        bigtestGlobals.appUrl = undefined;
+        globals.appUrl = undefined;
         await expect(Page.visit('/foobar')).rejects.toThrow('no app url defined');
       });
 
       it('throws an error if test frame is not defined', async () => {
-        bigtestGlobals.testFrame = undefined;
+        globals.testFrame = undefined;
         await expect(Page.visit('/foobar')).rejects.toThrow('no test frame defined');
       });
     });

--- a/packages/with-cypress/src/cypress.ts
+++ b/packages/with-cypress/src/cypress.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 /// <reference types="cypress" />
-import { bigtestGlobals, RunnerState } from '@bigtest/globals';
-import { Interaction, isInteraction, ReadonlyInteraction, setDocumentResolver } from '@interactors/html';
+import { Interaction, isInteraction, ReadonlyInteraction, setDocumentResolver, globals, RunnerState } from '@interactors/html';
 
 declare global {
   namespace Cypress {
@@ -18,7 +17,7 @@ function interact(
   interaction: Interaction<void> | ReadonlyInteraction<void>,
   runnerState: RunnerState
 ) {
-  bigtestGlobals.runnerState = runnerState;
+  globals.runnerState = runnerState;
   return cy.then(() => {
     return interaction;
   }).then(() => {


### PR DESCRIPTION
## Motivation

As the first step of #3

## Approach

Define interactors' globals object that uses bigtest globals under the hood. Then update bigtest to use interactors' globals instead. And after that replace bigtest globals inside the interactors' globals object to use global object