### PR TITLE
fix missing fallback file for testing library

### DIFF
--- a/.changeset/two-tigers-sleep.md
+++ b/.changeset/two-tigers-sleep.md
@@ -1,0 +1,5 @@
+---
+"@interactors/html": patch
+---
+
+fix missing fallback file for testing library

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -12,6 +12,7 @@
   "files": [
     "dist/**/*",
     "src/**/*",
+    "testing-library.*",
     "README.md"
   ],
   "exports": {


### PR DESCRIPTION
## Motivation

The `testing-library` fallback file with re-exports is missing in the published package https://npmfs.com/package/@interactors/html/0.33.0/

## Approach

Add it to `files` list in package.json
