### PR TITLE
Remove test suite wrappers

### DIFF
--- a/packages/html/test/create-interactor.test.ts
+++ b/packages/html/test/create-interactor.test.ts
@@ -58,7 +58,7 @@ const Datepicker = createInteractor<HTMLDivElement>("datepicker")
 const MainNav = createInteractor('main nav')
   .selector('nav')
 
-describe('@interactors/html', () => {
+describe('createInteractor', () => {
   describe('.exists', () => {
     it('can determine whether an element exists based on the interactor', async () => {
       dom(`

--- a/packages/html/test/extend.test.ts
+++ b/packages/html/test/extend.test.ts
@@ -41,75 +41,73 @@ const Header = createInteractor('header')
 //@ts-ignore
 const HTMLWithNoLabel = HTML.extend()
 
-describe('@interactors/html', () => {
-  describe('.extend', () => {
-    it('can use filters from base interactor', async () => {
-      dom(`
-        <p><a href="/foobar" title="Foo">Foo Bar</a></p>
-      `);
+describe('Interactor.extend', () => {
+  it('can use filters from base interactor', async () => {
+    dom(`
+      <p><a href="/foobar" title="Foo">Foo Bar</a></p>
+    `);
 
-      await expect(Link('Foo Bar').has({ title: "Foo" })).resolves.toBeUndefined();
-      await expect(Link('Foo Bar').has({ title: "Quox" })).rejects.toHaveProperty('message', [
-        'link "Foo Bar" does not match filters:', '',
-        '╒═ Filter:   title',
-        '├─ Expected: "Quox"',
-        '└─ Received: "Foo"',
-      ].join('\n'));
-    });
+    await expect(Link('Foo Bar').has({ title: "Foo" })).resolves.toBeUndefined();
+    await expect(Link('Foo Bar').has({ title: "Quox" })).rejects.toHaveProperty('message', [
+      'link "Foo Bar" does not match filters:', '',
+      '╒═ Filter:   title',
+      '├─ Expected: "Quox"',
+      '└─ Received: "Foo"',
+    ].join('\n'));
+  });
 
-    it('can use filters from extended interactor', async () => {
-      dom(`
-        <p><a href="/foobar" title="Foo">Foo Bar</a></p>
-      `);
+  it('can use filters from extended interactor', async () => {
+    dom(`
+      <p><a href="/foobar" title="Foo">Foo Bar</a></p>
+    `);
 
-      await expect(Link('Foo Bar').has({ href: "/foobar" })).resolves.toBeUndefined();
-      await expect(Link('Foo Bar').has({ href: "/quox" })).rejects.toHaveProperty('message', [
-        'link "Foo Bar" does not match filters:', '',
-        '╒═ Filter:   href',
-        '├─ Expected: "/quox"',
-        '└─ Received: "/foobar"',
-      ].join('\n'));
-    });
+    await expect(Link('Foo Bar').has({ href: "/foobar" })).resolves.toBeUndefined();
+    await expect(Link('Foo Bar').has({ href: "/quox" })).rejects.toHaveProperty('message', [
+      'link "Foo Bar" does not match filters:', '',
+      '╒═ Filter:   href',
+      '├─ Expected: "/quox"',
+      '└─ Received: "/foobar"',
+    ].join('\n'));
+  });
 
-    it('can use actions from base interactor', async () => {
-      dom(`
-        <a id="foo" href="/foobar">Foo Bar</a>
-        <div id="target"></div>
-        <script>
-          foo.onclick = () => {
-            target.innerHTML = '<h1>Hello!</h1>';
-          }
-        </script>
-      `);
+  it('can use actions from base interactor', async () => {
+    dom(`
+      <a id="foo" href="/foobar">Foo Bar</a>
+      <div id="target"></div>
+      <script>
+        foo.onclick = () => {
+          target.innerHTML = '<h1>Hello!</h1>';
+        }
+      </script>
+    `);
 
-      await Link('Foo Bar').click();
-      await Header('Hello!').exists();
-    });
+    await Link('Foo Bar').click();
+    await Header('Hello!').exists();
+  });
 
-    it('can use actions from extended interactor', async () => {
-      dom(`
-        <a id="foo" href="/foobar">Foo Bar</a>
-      `);
+  it('can use actions from extended interactor', async () => {
+    dom(`
+      <a id="foo" href="/foobar">Foo Bar</a>
+    `);
 
-      await Link('Foo Bar').setHref('/monkey');
-      await Link({ href: '/monkey' }).exists();
-    });
+    await Link('Foo Bar').setHref('/monkey');
+    await Link({ href: '/monkey' }).exists();
+  });
 
-    it('can use overridden filters and actions', async () => {
-      dom(`
-        <div></div>
-      `);
+  it('can use overridden filters and actions', async () => {
+    dom(`
+      <div></div>
+    `);
 
-      await Thing().click(4);
-      await Thing().has({ title: 4 });
-    });
+    await Thing().click(4);
+    await Thing().has({ title: 4 });
+  });
 
-    it('throws error if interactor has no label', async () => {
-      dom(`<p>Foo Bar</p>`);
-      await expect(HTMLWithNoLabel('Foo Bar').exists()).rejects.toHaveProperty('message', [
-        "One of your interactors was created without a name. Please provide a label for your interactor:",
-        "\tHTML.extend('my interactor') || createInteractor('my interactor')"
-      ].join('\n'));
-    });
+  it('throws error if interactor has no label', async () => {
+    dom(`<p>Foo Bar</p>`);
+    await expect(HTMLWithNoLabel('Foo Bar').exists()).rejects.toHaveProperty('message', [
+      "One of your interactors was created without a name. Please provide a label for your interactor:",
+      "\tHTML.extend('my interactor') || createInteractor('my interactor')"
+    ].join('\n'));
   });
 });

--- a/packages/html/test/inspector.test.ts
+++ b/packages/html/test/inspector.test.ts
@@ -6,21 +6,19 @@ import { createInspector, createInteractor, including, Link } from '../src/index
 
 const Div = createInteractor('div').selector('div')
 
-describe('@interactors/html', () => {
-  describe('inspector', () => {
-    it('.find', async () => {
-      dom(`
-        <div><a href="/foo">Foo</a></div>
-        <div><a href="/bar&quot;">Foo</a></div>
-      `);
+describe('inspector', () => {
+  it('.find', async () => {
+    dom(`
+      <div><a href="/foo">Foo</a></div>
+      <div><a href="/bar&quot;">Foo</a></div>
+    `);
 
-      let divs = createInspector(Div).all()
+    let divs = createInspector(Div).all()
 
-      expect(divs.length).toEqual(2)
+    expect(divs.length).toEqual(2)
 
-      let links = divs.map(div => div.find(Link).all()).reduce((a, b) => a.concat(b))
+    let links = divs.map(div => div.find(Link).all()).reduce((a, b) => a.concat(b))
 
-      await expect(Promise.all(links.map(e => e.has({ href: including('/') })))).resolves
-    });
+    await expect(Promise.all(links.map(e => e.has({ href: including('/') })))).resolves
   });
 });

--- a/packages/html/test/interactor.test.ts
+++ b/packages/html/test/interactor.test.ts
@@ -6,7 +6,7 @@ import { createInteractor, Link, Heading } from '../src';
 
 const MainNav = createInteractor('main nav').selector('nav');
 
-describe('@interactors/html', () => {
+describe('Interactor', () => {
   describe('instantiation', () => {
     describe('no arguments', () => {
       it('just uses the selector to locate', async () => {

--- a/packages/html/test/matcher.test.ts
+++ b/packages/html/test/matcher.test.ts
@@ -21,69 +21,67 @@ function shouted(value: string): Matcher<string> {
   }
 }
 
-describe('@interactors/html', () => {
-  describe('matchers', () => {
-    it('can use matcher on locator when locating element', async () => {
-      dom(`
-        <p><a href="/foobar">FOO</a></p>
-        <p><a href="/foobar">BAR</a></p>
-      `);
+describe('matchers', () => {
+  it('can use matcher on locator when locating element', async () => {
+    dom(`
+      <p><a href="/foobar">FOO</a></p>
+      <p><a href="/foobar">BAR</a></p>
+    `);
 
-      await expect(Link(shouted('Foo')).exists()).resolves.toBeUndefined();
-      await expect(Link(shouted('Quox')).exists()).rejects.toHaveProperty('message', [
-        'did not find link uppercase "QUOX", did you mean one of:', '',
-        '┃ link    ┃',
-        '┣━━━━━━━━━┫',
-        '┃ ⨯ "FOO" ┃',
-        '┃ ⨯ "BAR" ┃',
-      ].join('\n'));
-    });
-
-    it('can use matcher on filter when locating element', async () => {
-      dom(`
-        <p><a href="/foobar" title="FOO">Foo Bar</a></p>
-        <p><a href="/foobar" title="BAR">Quox</a></p>
-      `);
-
-      await expect(Link('Foo Bar', { title: shouted('foo') }).exists()).resolves.toBeUndefined();
-      await expect(Link('Foo Bar', { title: shouted('bar') }).exists()).rejects.toHaveProperty('message', [
-        'did not find link "Foo Bar" with title uppercase "BAR", did you mean one of:', '',
-        '┃ link        ┃ title: uppercase "BAR" ┃',
-        '┣━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━┫',
-        '┃ ✓ "Foo Bar" ┃ ⨯ "FOO"                ┃',
-        '┃ ⨯ "Quox"    ┃ ✓ "BAR"                ┃',
-      ].join('\n'));
-    });
-
-    it('can use matcher on filter when matching element', async () => {
-      dom(`
-        <p><a href="/foobar" title="FOO">Foo Bar</a></p>
-        <p><a href="/foobar" title="BAR">Quox</a></p>
-      `);
-
-      await expect(Link('Foo Bar').has({ title: shouted('foo') })).resolves.toBeUndefined();
-      await expect(Link('Foo Bar').has({ title: shouted('bar') })).rejects.toHaveProperty('message', [
-        'link "Foo Bar" does not match filters:', '',
-        '╒═ Filter:   title',
-        '├─ Expected: uppercase "BAR"',
-        '└─ Received: "FOO"',
-      ].join('\n'));
-    });
-
-    it('can use regex on locator when locating element', async () => {
-      dom(`
-        <p><a href="/foobar">FOO</a></p>
-        <p><a href="/foobar">BAR</a></p>
-      `);
-
-      await expect(Link(/foo/i).exists()).resolves.toBeUndefined();
-      await expect(Link(/quox/i).exists()).rejects.toHaveProperty('message', [
-        'did not find link matching /quox/i, did you mean one of:', '',
-        '┃ link    ┃',
-        '┣━━━━━━━━━┫',
-        '┃ ⨯ "FOO" ┃',
-        '┃ ⨯ "BAR" ┃',
-      ].join('\n'));
-    })
+    await expect(Link(shouted('Foo')).exists()).resolves.toBeUndefined();
+    await expect(Link(shouted('Quox')).exists()).rejects.toHaveProperty('message', [
+      'did not find link uppercase "QUOX", did you mean one of:', '',
+      '┃ link    ┃',
+      '┣━━━━━━━━━┫',
+      '┃ ⨯ "FOO" ┃',
+      '┃ ⨯ "BAR" ┃',
+    ].join('\n'));
   });
+
+  it('can use matcher on filter when locating element', async () => {
+    dom(`
+      <p><a href="/foobar" title="FOO">Foo Bar</a></p>
+      <p><a href="/foobar" title="BAR">Quox</a></p>
+    `);
+
+    await expect(Link('Foo Bar', { title: shouted('foo') }).exists()).resolves.toBeUndefined();
+    await expect(Link('Foo Bar', { title: shouted('bar') }).exists()).rejects.toHaveProperty('message', [
+      'did not find link "Foo Bar" with title uppercase "BAR", did you mean one of:', '',
+      '┃ link        ┃ title: uppercase "BAR" ┃',
+      '┣━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━┫',
+      '┃ ✓ "Foo Bar" ┃ ⨯ "FOO"                ┃',
+      '┃ ⨯ "Quox"    ┃ ✓ "BAR"                ┃',
+    ].join('\n'));
+  });
+
+  it('can use matcher on filter when matching element', async () => {
+    dom(`
+      <p><a href="/foobar" title="FOO">Foo Bar</a></p>
+      <p><a href="/foobar" title="BAR">Quox</a></p>
+    `);
+
+    await expect(Link('Foo Bar').has({ title: shouted('foo') })).resolves.toBeUndefined();
+    await expect(Link('Foo Bar').has({ title: shouted('bar') })).rejects.toHaveProperty('message', [
+      'link "Foo Bar" does not match filters:', '',
+      '╒═ Filter:   title',
+      '├─ Expected: uppercase "BAR"',
+      '└─ Received: "FOO"',
+    ].join('\n'));
+  });
+
+  it('can use regex on locator when locating element', async () => {
+    dom(`
+      <p><a href="/foobar">FOO</a></p>
+      <p><a href="/foobar">BAR</a></p>
+    `);
+
+    await expect(Link(/foo/i).exists()).resolves.toBeUndefined();
+    await expect(Link(/quox/i).exists()).rejects.toHaveProperty('message', [
+      'did not find link matching /quox/i, did you mean one of:', '',
+      '┃ link    ┃',
+      '┣━━━━━━━━━┫',
+      '┃ ⨯ "FOO" ┃',
+      '┃ ⨯ "BAR" ┃',
+    ].join('\n'));
+  })
 });

--- a/packages/html/test/matchers/and.test.ts
+++ b/packages/html/test/matchers/and.test.ts
@@ -4,26 +4,24 @@ import { dom } from '../helpers';
 
 import { HTML, and, including } from '../../src/index';
 
-describe('@interactors/html', () => {
-  describe('and', () => {
-    it('can check whether the given value matches all of the given matchers', async () => {
-      dom(`
-        <div title="hello cruel world"></div>
-      `);
+describe('and', () => {
+  it('can check whether the given value matches all of the given matchers', async () => {
+    dom(`
+      <div title="hello cruel world"></div>
+    `);
 
-      await HTML({ title: and(including('world'), including('hello')) }).exists();
-      await HTML({ title: and(including('world'), including('hello'), including('cruel')) }).exists();
-      await expect(HTML({ title: and(including('world'), including('monkey')) }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError')
-      await expect(HTML({ title: and(including('monkey'), including('hello')) }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError')
-    });
+    await HTML({ title: and(including('world'), including('hello')) }).exists();
+    await HTML({ title: and(including('world'), including('hello'), including('cruel')) }).exists();
+    await expect(HTML({ title: and(including('world'), including('monkey')) }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError')
+    await expect(HTML({ title: and(including('monkey'), including('hello')) }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError')
+  });
 
-    it('can check whether the given value matches all of the given actual values', async () => {
-      dom(`
-        <div title="hello"></div>
-      `);
+  it('can check whether the given value matches all of the given actual values', async () => {
+    dom(`
+      <div title="hello"></div>
+    `);
 
-      await HTML({ title: and('hello', 'hello') }).exists();
-      await expect(HTML({ title: and('hello', 'monkey') }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError')
-    });
+    await HTML({ title: and('hello', 'hello') }).exists();
+    await expect(HTML({ title: and('hello', 'monkey') }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError')
   });
 });

--- a/packages/html/test/matchers/every.test.ts
+++ b/packages/html/test/matchers/every.test.ts
@@ -4,18 +4,16 @@ import { dom } from '../helpers';
 
 import { MultiSelect, every, including } from '../../src/index';
 
-describe('@interactors/html', () => {
-  describe('every', () => {
-    it('can check whether the given string is contained in an array', async () => {
-      dom(`
-        <select id="colors" multiple>
-          <option selected>Neon Blue</option>
-          <option selected>Neon Green</option>
-        </select>
-      `);
+describe('every', () => {
+  it('can check whether the given string is contained in an array', async () => {
+    dom(`
+      <select id="colors" multiple>
+        <option selected>Neon Blue</option>
+        <option selected>Neon Green</option>
+      </select>
+    `);
 
-      await MultiSelect({ id: 'colors' }).has({ values: every(including('Neon')) });
-      await expect(MultiSelect({ id: 'colors' }).has({ values: every(including('Blue')) })).rejects.toHaveProperty('name', 'FilterNotMatchingError')
-    });
+    await MultiSelect({ id: 'colors' }).has({ values: every(including('Neon')) });
+    await expect(MultiSelect({ id: 'colors' }).has({ values: every(including('Blue')) })).rejects.toHaveProperty('name', 'FilterNotMatchingError')
   });
 });

--- a/packages/html/test/matchers/including.test.ts
+++ b/packages/html/test/matchers/including.test.ts
@@ -4,16 +4,14 @@ import { dom } from '../helpers';
 
 import { HTML, including } from '../../src/index';
 
-describe('@interactors/html', () => {
-  describe('including', () => {
-    it('can check whether the given string is contained', async () => {
-      dom(`
-        <div title="hello world"></div>
-      `);
+describe('including', () => {
+  it('can check whether the given string is contained', async () => {
+    dom(`
+      <div title="hello world"></div>
+    `);
 
-      await HTML({ title: including('hello') }).exists();
-      await HTML({ title: including('world') }).exists();
-      await expect(HTML({ title: including('blah') }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError')
-    });
+    await HTML({ title: including('hello') }).exists();
+    await HTML({ title: including('world') }).exists();
+    await expect(HTML({ title: including('blah') }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError')
   });
 });

--- a/packages/html/test/matchers/matching.test.ts
+++ b/packages/html/test/matchers/matching.test.ts
@@ -4,7 +4,7 @@ import { dom } from '../helpers';
 
 import { HTML, matching } from '../../src/index';
 
-describe('@interactors/html', () => {
+describe('matching', () => {
   beforeEach(() => {
     dom(`
       <div title="hello world"></div>
@@ -12,10 +12,8 @@ describe('@interactors/html', () => {
     `);
   });
 
-  describe('matching', () => {
-    it('can check whether the given string matching', async () => {
-      await HTML({ title: matching(/he(llo|ck)/) }).exists();
-      await expect(HTML({ title: matching(/blah/) }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError')
-    });
+  it('can check whether the given string matching', async () => {
+    await HTML({ title: matching(/he(llo|ck)/) }).exists();
+    await expect(HTML({ title: matching(/blah/) }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError')
   });
 });

--- a/packages/html/test/matchers/not.test.ts
+++ b/packages/html/test/matchers/not.test.ts
@@ -7,25 +7,22 @@ import { HTML, not, including } from '../../src/index';
 
 const div = HTML({ id: "test-div" });
 
-describe('@interactors/html', () => {
+describe('not', () => {
+  it('can check whether the filter does not match the given matcher', async () => {
+    dom(`
+      <div id="test-div" title="hello cruel world"></div>
+    `);
 
-  describe('not', () => {
-    it('can check whether the filter does not match the given matcher', async () => {
-      dom(`
-        <div id="test-div" title="hello cruel world"></div>
-      `);
+    await div.has({ title: not(including("monkey")) });
+    await expect(div.has({ title: not(including('world')) })).rejects.toHaveProperty('name', 'FilterNotMatchingError');
+  });
 
-      await div.has({ title: not(including("monkey")) });
-      await expect(div.has({ title: not(including('world')) })).rejects.toHaveProperty('name', 'FilterNotMatchingError');
-    });
+  it('can check whether the filter does not match the given literal value', async () => {
+    dom(`
+      <div id="test-div" title="hello"></div>
+    `);
 
-    it('can check whether the filter does not match the given literal value', async () => {
-      dom(`
-        <div id="test-div" title="hello"></div>
-      `);
-
-      await div.has({ title: not('monkey') });
-      await expect(div.has({ title: not('hello') })).rejects.toHaveProperty('name', 'FilterNotMatchingError');
-    });
+    await div.has({ title: not('monkey') });
+    await expect(div.has({ title: not('hello') })).rejects.toHaveProperty('name', 'FilterNotMatchingError');
   });
 });

--- a/packages/html/test/matchers/or.test.ts
+++ b/packages/html/test/matchers/or.test.ts
@@ -4,25 +4,23 @@ import { dom } from '../helpers';
 
 import { HTML, or, including } from '../../src/index';
 
-describe('@interactors/html', () => {
-  describe('or', () => {
-    it('can check whether the given value matches any of the given matchers', async () => {
-      dom(`
-        <div title="hello cruel world"></div>
-      `);
+describe('or', () => {
+  it('can check whether the given value matches any of the given matchers', async () => {
+    dom(`
+      <div title="hello cruel world"></div>
+    `);
 
-      await HTML({ title: or(including('world'), including('hello')) }).exists();
-      await HTML({ title: or(including('world'), including('blah')) }).exists();
-      await expect(HTML({ title: or(including('blah'), including('monkey')) }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError')
-    });
+    await HTML({ title: or(including('world'), including('hello')) }).exists();
+    await HTML({ title: or(including('world'), including('blah')) }).exists();
+    await expect(HTML({ title: or(including('blah'), including('monkey')) }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError')
+  });
 
-    it('can check whether the given value matches any of the given actual values', async () => {
-      dom(`
-        <div title="hello"></div>
-      `);
+  it('can check whether the given value matches any of the given actual values', async () => {
+    dom(`
+      <div title="hello"></div>
+    `);
 
-      await HTML({ title: or('hello', 'world') }).exists();
-      await expect(HTML({ title: or('blah', 'monkey') }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError')
-    });
+    await HTML({ title: or('hello', 'world') }).exists();
+    await expect(HTML({ title: or('blah', 'monkey') }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError')
   });
 });

--- a/packages/html/test/matchers/some.test.ts
+++ b/packages/html/test/matchers/some.test.ts
@@ -4,22 +4,20 @@ import { dom } from '../helpers';
 
 import { MultiSelect, some, including } from '../../src/index';
 
-describe('@interactors/html', () => {
-  describe('some', () => {
-    it('can check whether the given string is contained in an array', async () => {
-      dom(`
-        <select id="colors" multiple>
-          <option selected>Red</option>
-          <option selected>Blue</option>
-          <option selected>Green</option>
-          <option selected>Neon Blue</option>
-          <option selected>Neon Green</option>
-        </select>
-      `);
+describe('some', () => {
+  it('can check whether the given string is contained in an array', async () => {
+    dom(`
+      <select id="colors" multiple>
+        <option selected>Red</option>
+        <option selected>Blue</option>
+        <option selected>Green</option>
+        <option selected>Neon Blue</option>
+        <option selected>Neon Green</option>
+      </select>
+    `);
 
-      await MultiSelect({ id: 'colors' }).has({ values: some('Red') });
-      await MultiSelect({ id: 'colors' }).has({ values: some(including('Neon')) });
-      await expect(MultiSelect({ id: 'colors' }).has({ values: some('Yellow') })).rejects.toHaveProperty('name', 'FilterNotMatchingError')
-    });
+    await MultiSelect({ id: 'colors' }).has({ values: some('Red') });
+    await MultiSelect({ id: 'colors' }).has({ values: some(including('Neon')) });
+    await expect(MultiSelect({ id: 'colors' }).has({ values: some('Yellow') })).rejects.toHaveProperty('name', 'FilterNotMatchingError')
   });
 });

--- a/packages/html/test/page.test.ts
+++ b/packages/html/test/page.test.ts
@@ -10,104 +10,102 @@ import { dom } from './helpers';
 
 import { globals, Page, read, setDocumentResolver } from '../src';
 
-describe('@interactors/html', function() {
-  describe('Page', () => {
-    describe('visit', () => {
-      let jsdom: JSDOM;
-      let server: Server;
+describe('Page', () => {
+  describe('visit', () => {
+    let jsdom: JSDOM;
+    let server: Server;
 
-      beforeEach(async () => {
-        globals.reset();
+    beforeEach(async () => {
+      globals.reset();
 
-        let app = express();
+      let app = express();
 
-        app.get('/', (req, res) => {
-          setTimeout(function() {
-            res.writeHead(200, {'Content-Type': 'text/html'});
-            res.write('<!doctype html><html><h1>Homepage</h1></html>');
-            res.end();
-          }, 20);
-        });
-
-        app.get('/foobar', (req, res) => {
+      app.get('/', (req, res) => {
+        setTimeout(function() {
           res.writeHead(200, {'Content-Type': 'text/html'});
-          res.write('<!doctype html><html><h1>On foobar!</h1></html>');
+          res.write('<!doctype html><html><h1>Homepage</h1></html>');
           res.end();
-        });
-
-        server = app.listen(27000);
-
-        let resources = new ResourceLoader({ proxy: "http://localhost:27000" });
-        jsdom = new JSDOM(`<!doctype html><html><body><iframe/></body></html>`, { resources });
-        bigtestGlobals.testFrame = jsdom.window.document.querySelector('iframe') as HTMLIFrameElement;
-        setDocumentResolver(() => bigtestGlobals.testFrame?.contentDocument as Document);
-        bigtestGlobals.appUrl = 'http://example.com';
+        }, 20);
       });
 
-      afterEach(() => {
-        server?.close();
-        jsdom?.window?.close();
+      app.get('/foobar', (req, res) => {
+        res.writeHead(200, {'Content-Type': 'text/html'});
+        res.write('<!doctype html><html><h1>On foobar!</h1></html>');
+        res.end();
       });
 
-      it('can load the app by visiting the root path', async () => {
-        await Page.visit();
-        await expect(read(Page, 'url')).resolves.toEqual('http://example.com/');
-      });
+      server = app.listen(27000);
 
-      it('can load the app by visiting the given path', async () => {
-        await Page.visit('/foobar');
-        await expect(read(Page, 'url')).resolves.toEqual('http://example.com/foobar');
-      });
-
-      it('can reload the app by visiting changed url hash', async () => {
-        await Page.visit('/#/foo');
-        await expect(read(Page, 'url')).resolves.toEqual('http://example.com/#/foo');
-        await Page.visit('/#/bar');
-        await expect(read(Page, 'url')).resolves.toEqual('http://example.com/#/bar');
-      });
-
-      it('is an interaction which can describe itself', async () => {
-        expect(Page.visit('/foobar').description).toEqual('visiting "/foobar"');
-      });
-
-      it('throws an error if app url is not defined', async () => {
-        bigtestGlobals.appUrl = undefined;
-        await expect(Page.visit('/foobar')).rejects.toThrow('no app url defined');
-      });
-
-      it('throws an error if test frame is not defined', async () => {
-        bigtestGlobals.testFrame = undefined;
-        await expect(Page.visit('/foobar')).rejects.toThrow('no test frame defined');
-      });
+      let resources = new ResourceLoader({ proxy: "http://localhost:27000" });
+      jsdom = new JSDOM(`<!doctype html><html><body><iframe/></body></html>`, { resources });
+      bigtestGlobals.testFrame = jsdom.window.document.querySelector('iframe') as HTMLIFrameElement;
+      setDocumentResolver(() => bigtestGlobals.testFrame?.contentDocument as Document);
+      bigtestGlobals.appUrl = 'http://example.com';
     });
 
-    describe('filter `title`', () => {
-      it('can check the page title', async() => {
-        let window = dom('');
-        window.document.title = 'Hello World';
-
-        await expect(Page.has({ title: 'Hello World' })).resolves.toBeUndefined();
-        await expect(Page.has({ title: 'Does Not Exist' })).rejects.toHaveProperty('message', [
-          'page does not match filters:', '',
-          '╒═ Filter:   title',
-          '├─ Expected: "Does Not Exist"',
-          '└─ Received: "Hello World"',
-        ].join('\n'))
-      });
+    afterEach(() => {
+      server?.close();
+      jsdom?.window?.close();
     });
 
-    describe('filter `url`', () => {
-      it('can check the page url', async() => {
-        dom('');
+    it('can load the app by visiting the root path', async () => {
+      await Page.visit();
+      await expect(read(Page, 'url')).resolves.toEqual('http://example.com/');
+    });
 
-        await expect(Page.has({ url: 'about:blank' })).resolves.toBeUndefined();
-        await expect(Page.has({ url: 'does-not-exist' })).rejects.toHaveProperty('message', [
-          'page does not match filters:', '',
-          '╒═ Filter:   url',
-          '├─ Expected: "does-not-exist"',
-          '└─ Received: "about:blank"',
-        ].join('\n'))
-      });
+    it('can load the app by visiting the given path', async () => {
+      await Page.visit('/foobar');
+      await expect(read(Page, 'url')).resolves.toEqual('http://example.com/foobar');
+    });
+
+    it('can reload the app by visiting changed url hash', async () => {
+      await Page.visit('/#/foo');
+      await expect(read(Page, 'url')).resolves.toEqual('http://example.com/#/foo');
+      await Page.visit('/#/bar');
+      await expect(read(Page, 'url')).resolves.toEqual('http://example.com/#/bar');
+    });
+
+    it('is an interaction which can describe itself', async () => {
+      expect(Page.visit('/foobar').description).toEqual('visiting "/foobar"');
+    });
+
+    it('throws an error if app url is not defined', async () => {
+      bigtestGlobals.appUrl = undefined;
+      await expect(Page.visit('/foobar')).rejects.toThrow('no app url defined');
+    });
+
+    it('throws an error if test frame is not defined', async () => {
+      bigtestGlobals.testFrame = undefined;
+      await expect(Page.visit('/foobar')).rejects.toThrow('no test frame defined');
+    });
+  });
+
+  describe('filter `title`', () => {
+    it('can check the page title', async() => {
+      let window = dom('');
+      window.document.title = 'Hello World';
+
+      await expect(Page.has({ title: 'Hello World' })).resolves.toBeUndefined();
+      await expect(Page.has({ title: 'Does Not Exist' })).rejects.toHaveProperty('message', [
+        'page does not match filters:', '',
+        '╒═ Filter:   title',
+        '├─ Expected: "Does Not Exist"',
+        '└─ Received: "Hello World"',
+      ].join('\n'))
+    });
+  });
+
+  describe('filter `url`', () => {
+    it('can check the page url', async() => {
+      dom('');
+
+      await expect(Page.has({ url: 'about:blank' })).resolves.toBeUndefined();
+      await expect(Page.has({ url: 'does-not-exist' })).rejects.toHaveProperty('message', [
+        'page does not match filters:', '',
+        '╒═ Filter:   url',
+        '├─ Expected: "does-not-exist"',
+        '└─ Received: "about:blank"',
+      ].join('\n'))
     });
   });
 });


### PR DESCRIPTION
A lot of the tests are wrapped in describes for `@interactors/html`, this really contributes nothing aside from an added level of indentation. Let's just get rid of it.