### PR TITLE
Avoid circular wording when describing matchers

### DIFF
--- a/website/docs/5-matchers.md
+++ b/website/docs/5-matchers.md
@@ -154,7 +154,7 @@ MultiSelect().has({ values: every(blueOrGreen) });
 
 To create your own matcher without the use of any of the preexisting ones, you will need to create a function that returns a `{ match(), description() }` object.
 
-The `match()` function is where you place all of the matcher logic. It takes one argument, `actual`, which represents the values from the interactors. Here's how the `including()` matcher is implemented:
+The `match()` function returns a boolean value indicating whether a filter or locator matches. It takes a single argument, `actual`, which is the current value of the filter or locator. Here's how the `including()` matcher is implemented:
 
 ```js
 export function including(subString) {


### PR DESCRIPTION
## Motivation

"math() is the function where you do the match()" is self-referential, and can be better explained.

## Approach

Try to describe what it does rather than what it is.