### PR TITLE
Specifically call out nomenclature

### DIFF
--- a/website/docs/3-locators-filters-actions.md
+++ b/website/docs/3-locators-filters-actions.md
@@ -3,7 +3,7 @@ id: locators-filters-actions
 title: Locators, Filters, and Actions
 ---
 
-Whether they are predefined or written by you, all interactors have some things in common. They have to be able to find elements in the page and manipulate them like a user would. To do these things, Interactors use a locator, filters, and actions.
+Whether they are predefined or written by you, all interactors have some things in common. They have to be able to find elements in the page and manipulate them like a user would. To do these things, Interactors use a _locator_, _filters_, and _actions_.
 
 ## The Locator
 


### PR DESCRIPTION
## Motivation

In the context of interactors, the terms "locator", "filter", and "action" have a very specific meaning, and we want to emphasize this as something that will be referred to often and so understanding is allowed to be precise.

## Approach

Use _emphasis_, but not a `literal` since they are not so much an API (though they are that in cases) but more of a underlying pattern.

