### PR TITLE
Add details interactor

### DIFF
--- a/.changeset/hot-ligers-compete.md
+++ b/.changeset/hot-ligers-compete.md
@@ -1,0 +1,5 @@
+---
+"@interactors/html": minor
+---
+
+Add Details interactor

--- a/packages/html/src/details.ts
+++ b/packages/html/src/details.ts
@@ -1,0 +1,39 @@
+import { HTML, innerText } from './html';
+
+const SummaryInteractor = HTML.extend('summary').selector('summary');
+
+const DetailsInteractor = HTML.extend<HTMLDetailsElement>('details')
+  .locator((e) => innerText(e.querySelector('summary')))
+  .selector('details')
+  .filters({
+    open: (element) => element.open,
+  })
+  .actions({
+    async toggle(interactor) {
+      await interactor.find(SummaryInteractor()).click();
+    }
+  });
+
+/**
+ * Call this {@link InteractorConstructor} to initialize a details {@link Interactor}. Which
+ * locates `details` tags by their summary.
+ *
+ * ### Example
+ *
+ * ``` typescript
+ * await Details('Show more').toggle();
+ * await Details('Show more').is({ open: true });
+ * ```
+ *
+ * ### Filters
+ *
+ * - `open`: *boolean* – Whether the details tag is open
+ * - `visible`: *boolean* – Filter by visibility. Defaults to `true`. See {@link isVisible}.
+ *
+ * ### Actions
+ *
+ * - `toggle()`: *{@link Interaction}* – show/hide the details
+ *
+ * @category Interactor
+ */
+export const Details = DetailsInteractor;

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -4,6 +4,7 @@ export * from '@interactors/globals';
 export { HTML } from './html';
 export { Page } from './page';
 export { FieldSet } from './field-set';
+export { Details } from './details';
 export { FormField } from './form-field';
 export { Link } from './link';
 export { Heading } from './heading';

--- a/packages/html/test/details.test.ts
+++ b/packages/html/test/details.test.ts
@@ -1,0 +1,50 @@
+import { describe, it } from 'mocha';
+import expect from 'expect';
+import { Details } from '../src/index';
+import { dom } from './helpers';
+
+describe('@interactors/html', () => {
+  describe('Details', () => {
+    it('finds `h1`, `h2`, etc... tags by text', async () => {
+      dom(`
+        <details>
+          <summary>Foo</summary>
+        </details>
+        <details>
+          <summary>Bar</summary>
+          Quox
+        </details>
+      `);
+
+      await expect(Details('Foo').exists()).resolves.toBeUndefined();
+      await expect(Details('Bar').exists()).resolves.toBeUndefined();
+      await expect(Details('Quox').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+    });
+
+    describe('filter `open`', () => {
+      it('filters details tags by whether they are open', async () => {
+        dom(`
+          <details open>
+            <summary>Foo</summary>
+          </details>
+        `);
+
+        await expect(Details('Foo', { open: true }).exists()).resolves.toBeUndefined();
+        await expect(Details('Foo', { open: false }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+      });
+    });
+
+    describe('.toggle', () => {
+      it('toggles whether details tag is open or closed', async () => {
+        dom(`
+          <details open>
+            <summary>Foo</summary>
+          </details>
+        `);
+
+        await Details('Foo').toggle();
+        await Details('Foo').is({ open: false });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This adds a simple interactor for the [`<details>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) tag.