### PR TITLE
Locator delegation

### DIFF
--- a/.changeset/cyan-owls-drive.md
+++ b/.changeset/cyan-owls-drive.md
@@ -1,0 +1,5 @@
+---
+"@interactors/material-ui": patch
+---
+
+Don't access locator option of another interactor

--- a/.changeset/short-peas-reflect.md
+++ b/.changeset/short-peas-reflect.md
@@ -1,0 +1,5 @@
+---
+"@interactors/html": minor
+---
+
+Reexport innerText function

--- a/.changeset/six-rings-stare.md
+++ b/.changeset/six-rings-stare.md
@@ -1,0 +1,5 @@
+---
+"@interactors/core": minor
+---
+
+Add locator delegation. Locators can be delegated to another delegator.

--- a/packages/core/src/constructor.ts
+++ b/packages/core/src/constructor.ts
@@ -268,9 +268,6 @@ export function createConstructor<E extends Element, FP extends FilterParams<any
       locator = new Locator(specification.locator || defaultLocator, locatorValue);
       filter = new FilterSet(specification, args[1] || {});
     } else {
-      if(typeof(specification.locator) === 'object' && specification.locator.default) {
-        locator = new Locator(specification.locator, specification.locator.default);
-      }
       filter = new FilterSet(specification, args[0] || {});
     }
     return instantiateInteractor({ name, specification, filter, locator, ancestors: [] });

--- a/packages/core/src/constructor.ts
+++ b/packages/core/src/constructor.ts
@@ -17,7 +17,7 @@ import {
   BaseInteractor,
   FilterObject,
 } from './specification';
-import { Filter } from './filter';
+import { FilterSet } from './filter-set';
 import { Locator } from './locator';
 import { MatchFilter, applyFilter } from './match';
 import { formatTable } from './format-table';
@@ -118,8 +118,8 @@ function description(options: InteractorOptions<any, any, any>): string {
  * assertion. Otherwise, it is not possible to make an assertion on a filter that might conflict
  * see https://github.com/thefrontside/bigtest/issues/966
 */
-function getLookupFilterForAssertion<E extends Element, F extends Filters<E>>(filter: Filter<E, F>, filters: FilterParams<E, F>): Filter<E, F> {
-  let lookupFilter = new Filter(filter.specification, Object.assign({}, filter.filters));
+function getLookupFilterForAssertion<E extends Element, F extends Filters<E>>(filter: FilterSet<E, F>, filters: FilterParams<E, F>): FilterSet<E, F> {
+  let lookupFilter = new FilterSet(filter.specification, Object.assign({}, filter.filters));
   let specFilters = lookupFilter.specification.filters;
   for (let key in specFilters) {
     if (typeof specFilters[key] !== 'function'
@@ -168,7 +168,7 @@ export function instantiateBaseInteractor<E extends Element, F extends Filters<E
     },
 
     is(filters: FilterParams<E, F>): ReadonlyInteraction<void> {
-      let filter = new Filter(options.specification, filters);
+      let filter = new FilterSet(options.specification, filters);
       return check(`${description(options)} matches filters: ${filter.description}`, () => {
         return converge(() => {
           let element = resolver({...options, filter: getLookupFilterForAssertion(options.filter, filters) });
@@ -266,9 +266,9 @@ export function createConstructor<E extends Element, FP extends FilterParams<any
     let locatorValue = args[0] instanceof RegExp ? matching(args[0]) : args[0]
     if (typeof(locatorValue) === 'string' || isMatcher(locatorValue)) {
       locator = new Locator(specification.locator || defaultLocator, locatorValue);
-      filter = new Filter(specification, args[1] || {});
+      filter = new FilterSet(specification, args[1] || {});
     } else {
-      filter = new Filter(specification, args[0] || {});
+      filter = new FilterSet(specification, args[0] || {});
     }
     return instantiateInteractor({ name, specification, filter, locator, ancestors: [] });
   }

--- a/packages/core/src/constructor.ts
+++ b/packages/core/src/constructor.ts
@@ -6,11 +6,11 @@ import { MergeObjects } from './merge-objects';
 import {
   InteractorOptions,
   ActionMethods,
-  LocatorFn,
   InteractorConstructor,
   Interactor,
   Filters,
   Actions,
+  FilterDefinition,
   FilterParams,
   FilterMethods,
   InteractorSpecification,
@@ -28,7 +28,7 @@ import { NoSuchElementError, NotAbsentError, AmbiguousElementError } from './err
 import { isMatcher } from './matcher';
 import { matching } from './matchers/matching';
 
-const defaultLocator: LocatorFn<Element> = (element) => element.textContent || "";
+const defaultLocator: FilterDefinition<string, Element> = (element) => element.textContent || "";
 const defaultSelector = 'div';
 
 export function findElements<E extends Element>(parentElement: Element, interactor: InteractorOptions<any, any, any>): E[] {
@@ -268,6 +268,9 @@ export function createConstructor<E extends Element, FP extends FilterParams<any
       locator = new Locator(specification.locator || defaultLocator, locatorValue);
       filter = new FilterSet(specification, args[1] || {});
     } else {
+      if(typeof(specification.locator) === 'object' && specification.locator.default) {
+        locator = new Locator(specification.locator, specification.locator.default);
+      }
       filter = new FilterSet(specification, args[0] || {});
     }
     return instantiateInteractor({ name, specification, filter, locator, ancestors: [] });
@@ -277,7 +280,7 @@ export function createConstructor<E extends Element, FP extends FilterParams<any
     selector: (value: string): InteractorConstructor<E, FP, FM, AM> => {
       return createConstructor(name, { ...specification, selector: value });
     },
-    locator: (value: LocatorFn<E>): InteractorConstructor<E, FP, FM, AM> => {
+    locator: (value: FilterDefinition<string, E>): InteractorConstructor<E, FP, FM, AM> => {
       return createConstructor(name, { ...specification, locator: value });
     },
     filters: <FR extends Filters<E>>(filters: FR): InteractorConstructor<E, MergeObjects<FP, FilterParams<E, FR>>, MergeObjects<FM, FilterMethods<E, FR>>, AM> => {

--- a/packages/core/src/filter-set.ts
+++ b/packages/core/src/filter-set.ts
@@ -2,7 +2,7 @@ import { Filters, FilterFn, FilterObject, FilterParams, InteractorSpecification 
 import { noCase } from 'change-case';
 import { matcherDescription } from './matcher';
 
-export class Filter<E extends Element, F extends Filters<E>> {
+export class FilterSet<E extends Element, F extends Filters<E>> {
   constructor(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     public specification: InteractorSpecification<E, F, any>,

--- a/packages/core/src/locator.ts
+++ b/packages/core/src/locator.ts
@@ -1,10 +1,15 @@
-import { LocatorFn } from './specification';
+import { FilterDefinition } from './specification';
 import { matcherDescription, MaybeMatcher } from './matcher';
+import { applyFilter } from './match';
 
 export class Locator<E extends Element> {
-  constructor(public locatorFn: LocatorFn<E>, public value: MaybeMatcher<string>) {}
+  constructor(private definition: FilterDefinition<string, E>, public value: MaybeMatcher<string>) {}
 
   get description(): string {
     return matcherDescription(this.value);
+  }
+
+  apply(element: E): string {
+    return applyFilter(this.definition, element);
   }
 }

--- a/packages/core/src/match.ts
+++ b/packages/core/src/match.ts
@@ -1,6 +1,6 @@
 import { Locator } from './locator';
 import { FilterSet } from './filter-set';
-import { Filters, FilterFn, FilterObject } from './specification';
+import { Filters, FilterDefinition } from './specification';
 import { escapeHtml } from './escape-html';
 import { MaybeMatcher, applyMatcher, matcherDescription } from './matcher';
 
@@ -105,7 +105,7 @@ export class MatchFilter<E extends Element, F extends Filters<E>> {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function applyFilter<T>(definition: FilterFn<T, any> | FilterObject<T, any>, element: Element): T {
+export function applyFilter<T>(definition: FilterDefinition<T, any>, element: Element): T {
   if(typeof(definition) === 'function') {
     return definition(element) as T;
   } else {

--- a/packages/core/src/match.ts
+++ b/packages/core/src/match.ts
@@ -60,7 +60,7 @@ export class MatchLocator<E extends Element> {
     public locator: Locator<E>,
   ) {
     this.expected = locator.value;
-    this.actual = locator.locatorFn(element);
+    this.actual = locator.apply(element);
     this.matches = applyMatcher(this.expected, this.actual);
   }
 

--- a/packages/core/src/match.ts
+++ b/packages/core/src/match.ts
@@ -1,5 +1,5 @@
 import { Locator } from './locator';
-import { Filter } from './filter';
+import { FilterSet } from './filter-set';
 import { Filters, FilterFn, FilterObject } from './specification';
 import { escapeHtml } from './escape-html';
 import { MaybeMatcher, applyMatcher, matcherDescription } from './matcher';
@@ -13,19 +13,19 @@ export class Match<E extends Element, F extends Filters<E>> {
 
   constructor(
     public element: E,
-    public filter: Filter<E, F>,
+    public filterSet: FilterSet<E, F>,
     public locator?: Locator<E>,
   ) {
     this.matchLocator = locator && new MatchLocator(element, locator);
-    this.matchFilter = new MatchFilter(element, filter);
+    this.matchFilter = new MatchFilter(element, filterSet);
     this.matches = (this.matchLocator ? this.matchLocator.matches : true) && this.matchFilter.matches;
   }
 
   asTableHeader(name: string): string[] {
     if(this.matchLocator) {
-      return [name, ...this.filter.asTableHeader()];
+      return [name, ...this.filterSet.asTableHeader()];
     } else {
-      return this.filter.asTableHeader();
+      return this.filterSet.asTableHeader();
     }
   }
 
@@ -83,7 +83,7 @@ export class MatchFilter<E extends Element, F extends Filters<E>> {
 
   constructor(
     public element: E,
-    public filter: Filter<E, F>,
+    public filter: FilterSet<E, F>,
   ) {
     this.items = Object.entries(filter.all).map(([key, expected]) => {
       return new MatchFilterItem(element, filter, key, expected)
@@ -119,7 +119,7 @@ export class MatchFilterItem<T, E extends Element, F extends Filters<E>> {
 
   constructor(
     public element: E,
-    public filter: Filter<E, F>,
+    public filter: FilterSet<E, F>,
     public key: string,
     public expected: MaybeMatcher<T>,
   ) {

--- a/packages/core/src/specification.ts
+++ b/packages/core/src/specification.ts
@@ -130,22 +130,6 @@ export interface Interactor<E extends Element, F extends FilterParams<any, any>>
 
 export type ActionFn<E extends Element> = (interactor: Interactor<E, EmptyObject>, ...args: any[]) => Promise<unknown>;
 
-/**
- * A function which given an element returns a string which can be used to
- * locate the element, for example by returning the elements text content, or
- * an attribute value.
- *
- * ### Example
- *
- * ``` typescript
- * const inputValue: LocatorFn<HTMLInputElement> = (element) => element.value;
- * ```
- *
- * @param element The element to extract a locator out of
- * @typeParam E The type of the element that the locator function operates on
- */
-export type LocatorFn<E extends Element> = (element: E) => string;
-
 export type FilterFn<T, E extends Element> = (element: E) => T;
 
 export type FilterObject<T, E extends Element> = {
@@ -174,7 +158,7 @@ export type InteractorSpecification<E extends Element, F extends Filters<E>, A e
    * parameter of an {@link InteractorConstructor} must match the value
    * returned from the locator function.
    */
-  locator?: LocatorFn<E>;
+  locator?: FilterDefinition<string, E>;
 }
 
 export type ActionMethods<E extends Element, A extends Actions<E>> = {
@@ -215,7 +199,7 @@ export type FilterParams<E extends Element, F extends Filters<E>> = keyof F exte
  */
 export interface InteractorConstructor<E extends Element, FP extends FilterParams<any, any>, FM extends FilterMethods<any, any>, AM extends ActionMethods<any, any>> {
   selector(value: string | SelectorFn<E>): InteractorConstructor<E, FP, FM, AM>;
-  locator(value: LocatorFn<E>): InteractorConstructor<E, FP, FM, AM>;
+  locator(value: FilterDefinition<string, E>): InteractorConstructor<E, FP, FM, AM>;
   filters<FR extends Filters<E>>(filters: FR): InteractorConstructor<E, MergeObjects<FP, FilterParams<E, FR>>, MergeObjects<FM, FilterMethods<E, FR>>, AM>;
   actions<AR extends Actions<E>>(actions: AR): InteractorConstructor<E, FP, FM, MergeObjects<AM, ActionMethods<E, AR>>>;
   extend<ER extends E = E>(name: string): InteractorConstructor<ER, FP, FM, AM>;

--- a/packages/core/src/specification.ts
+++ b/packages/core/src/specification.ts
@@ -129,7 +129,6 @@ export interface Interactor<E extends Element, F extends FilterParams<any, any>>
 }
 
 export type ActionFn<E extends Element> = (interactor: Interactor<E, EmptyObject>, ...args: any[]) => Promise<unknown>;
-export type FilterFn<T, E extends Element> = (element: E) => T;
 
 /**
  * A function which given an element returns a string which can be used to
@@ -147,12 +146,16 @@ export type FilterFn<T, E extends Element> = (element: E) => T;
  */
 export type LocatorFn<E extends Element> = (element: E) => string;
 
+export type FilterFn<T, E extends Element> = (element: E) => T;
+
 export type FilterObject<T, E extends Element> = {
   apply: FilterFn<T, E>;
   default?: T;
 }
 
-export type Filters<E extends Element> = Record<string, FilterFn<unknown, E> | FilterObject<unknown, E>>;
+export type FilterDefinition<T, E extends Element> = FilterFn<T, E> | FilterObject<T, E>;
+
+export type Filters<E extends Element> = Record<string, FilterDefinition<unknown, E>>;
 
 export type Actions<E extends Element> = Record<string, ActionFn<E>>;
 

--- a/packages/core/src/specification.ts
+++ b/packages/core/src/specification.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { Filter } from './filter';
+import { FilterSet } from './filter-set';
 import { Locator } from './locator';
 import { Interaction, ReadonlyInteraction } from './interaction';
 import { MergeObjects } from './merge-objects';
@@ -256,6 +256,6 @@ export type InteractorOptions<E extends Element, F extends Filters<E>, A extends
   name: string;
   specification: InteractorSpecification<E, F, A>;
   locator?: Locator<E>;
-  filter: Filter<E, F>;
+  filter: FilterSet<E, F>;
   ancestors: InteractorOptions<any, any, any>[];
 };

--- a/packages/core/test/locator.test.ts
+++ b/packages/core/test/locator.test.ts
@@ -49,23 +49,6 @@ describe('locator', () => {
     ].join('\n'));
   });
 
-  it('can set default value for locator', async () => {
-    const Paragraph = createInteractor('p')
-      .selector('p')
-      .locator({
-        apply: (e) => e.id,
-        default: 'bar-id',
-      })
-      .filters({ id: (e) => e.id });
-
-    dom(`
-      <p id="foo-id">Foo</p>
-      <p id="bar-id">Bar</p>
-    `);
-
-    await expect(Paragraph().id()).resolves.toEqual('bar-id');
-  });
-
   it('can delegate locator to other interactor', async () => {
     const Span = createInteractor('span').selector('span').filters({
       text: (e) => e.textContent || ""

--- a/packages/core/test/locator.test.ts
+++ b/packages/core/test/locator.test.ts
@@ -1,0 +1,93 @@
+import { describe, it } from 'mocha';
+import expect from 'expect';
+import { dom } from './helpers';
+
+import { createInteractor } from '../src';
+
+describe('locator', () => {
+  it('can use function as locator', async () => {
+    const Paragraph = createInteractor('p')
+      .selector('p')
+      .locator((e) => e.id);
+
+    dom(`
+      <p id="foo-id">Foo</p>
+      <p id="bar-id">Bar</p>
+    `);
+
+    await expect(Paragraph('foo-id').exists()).resolves.toBeUndefined();
+    await expect(Paragraph('bar-id').exists()).resolves.toBeUndefined();
+    await expect(Paragraph('quox-id').exists()).rejects.toHaveProperty('message', [
+      'did not find p "quox-id", did you mean one of:', '',
+      '┃ p          ┃',
+      '┣━━━━━━━━━━━━┫',
+      '┃ ⨯ "foo-id" ┃',
+      '┃ ⨯ "bar-id" ┃',
+    ].join('\n'));
+  });
+
+  it('can use object as locator', async () => {
+    const Paragraph = createInteractor('p')
+      .selector('p')
+      .locator({
+        apply: (e) => e.id
+      });
+
+    dom(`
+      <p id="foo-id">Foo</p>
+      <p id="bar-id">Bar</p>
+    `);
+
+    await expect(Paragraph('foo-id').exists()).resolves.toBeUndefined();
+    await expect(Paragraph('bar-id').exists()).resolves.toBeUndefined();
+    await expect(Paragraph('quox-id').exists()).rejects.toHaveProperty('message', [
+      'did not find p "quox-id", did you mean one of:', '',
+      '┃ p          ┃',
+      '┣━━━━━━━━━━━━┫',
+      '┃ ⨯ "foo-id" ┃',
+      '┃ ⨯ "bar-id" ┃',
+    ].join('\n'));
+  });
+
+  it('can set default value for locator', async () => {
+    const Paragraph = createInteractor('p')
+      .selector('p')
+      .locator({
+        apply: (e) => e.id,
+        default: 'bar-id',
+      })
+      .filters({ id: (e) => e.id });
+
+    dom(`
+      <p id="foo-id">Foo</p>
+      <p id="bar-id">Bar</p>
+    `);
+
+    await expect(Paragraph().id()).resolves.toEqual('bar-id');
+  });
+
+  it('can delegate locator to other interactor', async () => {
+    const Span = createInteractor('span').selector('span').filters({
+      text: (e) => e.textContent || ""
+    });
+
+    const Paragraph = createInteractor('p')
+      .selector('p')
+      .locator(Span().text());
+
+    dom(`
+      <p><span>Foo</span> Quox</p>
+      <p><span>Bar</span> Quox</p>
+    `);
+
+    await expect(Paragraph('Foo').exists()).resolves.toBeUndefined();
+    await expect(Paragraph('Bar').exists()).resolves.toBeUndefined();
+    await expect(Paragraph('Quox').exists()).rejects.toHaveProperty('message', [
+      'did not find p "Quox", did you mean one of:', '',
+      '┃ p       ┃',
+      '┣━━━━━━━━━┫',
+      '┃ ⨯ "Foo" ┃',
+      '┃ ⨯ "Bar" ┃',
+    ].join('\n'));
+  });
+});

--- a/packages/core/test/locator.test.ts
+++ b/packages/core/test/locator.test.ts
@@ -6,7 +6,7 @@ import { createInteractor } from '../src';
 
 describe('locator', () => {
   it('can use function as locator', async () => {
-    const Paragraph = createInteractor('p')
+    let Paragraph = createInteractor('p')
       .selector('p')
       .locator((e) => e.id);
 
@@ -27,7 +27,7 @@ describe('locator', () => {
   });
 
   it('can use object as locator', async () => {
-    const Paragraph = createInteractor('p')
+    let Paragraph = createInteractor('p')
       .selector('p')
       .locator({
         apply: (e) => e.id
@@ -50,11 +50,11 @@ describe('locator', () => {
   });
 
   it('can delegate locator to other interactor', async () => {
-    const Span = createInteractor('span').selector('span').filters({
+    let Span = createInteractor('span').selector('span').filters({
       text: (e) => e.textContent || ""
     });
 
-    const Paragraph = createInteractor('p')
+    let Paragraph = createInteractor('p')
       .selector('p')
       .locator(Span().text());
 

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -1,7 +1,7 @@
 export * from '@interactors/core';
 export * from '@interactors/globals';
 
-export { HTML } from './html';
+export { HTML, innerText } from './html';
 export { Page } from './page';
 export { FieldSet } from './field-set';
 export { Details } from './details';

--- a/packages/material-ui/src/checkbox.ts
+++ b/packages/material-ui/src/checkbox.ts
@@ -1,10 +1,8 @@
-import { isVisible, click, CheckBox as BaseCheckbox } from "@interactors/html";
+import { isVisible, click, CheckBox as BaseCheckbox, innerText } from "@interactors/html";
 
 const CheckboxInteractor = BaseCheckbox.extend("MUI Checkbox")
   .selector('[class*="MuiCheckbox-root"] input[type=checkbox]')
-  .locator(
-    (element) => (BaseCheckbox().options.specification.locator?.(element) || element.getAttribute("aria-label")) ?? ""
-  )
+  .locator((element) => element.labels ? innerText(Array.from(element.labels)[0]) : (element.getAttribute("aria-label") ?? ""))
   .filters({
     /**
      * Checkbox component does not set the native input element to indeterminate due to inconsistent behavior across browsers.


### PR DESCRIPTION
Closes #102 

## Motivation

This allows interactors to delegate their locator to another interactor's filters. Since the locator must (currently) always return a `string`, the filter that we delegate to must be of type `string` as well. This is useful for a huge number of interactors, which currently do cumbersome stuff with `querySelector` in their locators.

## Approach

We unify filters and locators a bit more, by basically stating that a locator is a filter of type `string`. This way we can use the same approach for applying a locator as an object, and the existing infrastructure we added for filter delegation can be used for locator delegation as well.

One caveat is that it is possible to set a default value for filters via the `default` option. I found that this doesn't really make sense for locators. I actually implemented this at first, which wasn't hard, but opted not to include it in this PR.

### Alternate Designs

We could make a more extensive design with separate types for `FilterDefinition` and `LocatorDefinition`, and then we could also add a type which is the cross section of these types, which we would apply to interactions. This would be a more "correct" solution, at the expense of adding even more types. I feel that we already have an overload of types and we should work to remove types, not add more. Which is why I didn't go for this.

### Possible Drawbacks or Risks

Just like with filter delegation, the interactor that is delegated to must be unique, otherwise applying the filter will fail. This might be somewhat unexpected, but this ship has pretty much already sailed anyway.