### PR TITLE
Add selector function

### DIFF
--- a/.changeset/tidy-tables-relax.md
+++ b/.changeset/tidy-tables-relax.md
@@ -1,0 +1,5 @@
+---
+"@interactors/core": minor
+---
+
+Selector can be a function to return arbitrary elements

--- a/packages/core/src/constructor.ts
+++ b/packages/core/src/constructor.ts
@@ -32,7 +32,9 @@ const defaultLocator: LocatorFn<Element> = (element) => element.textContent || "
 const defaultSelector = 'div';
 
 export function findElements<E extends Element>(parentElement: Element, interactor: InteractorOptions<any, any, any>): E[] {
-  if(interactor.specification.selector === ':root') {
+  if(typeof(interactor.specification.selector) === 'function') {
+    return interactor.specification.selector(parentElement);
+  } else if(interactor.specification.selector === ':root') {
     // this is a bit of a hack, because otherwise there isn't a good way of selecting the root element
     return [parentElement.ownerDocument.querySelector(':root') as E];
   } else {

--- a/packages/core/src/specification.ts
+++ b/packages/core/src/specification.ts
@@ -156,11 +156,13 @@ export type Filters<E extends Element> = Record<string, FilterFn<unknown, E> | F
 
 export type Actions<E extends Element> = Record<string, ActionFn<E>>;
 
+export type SelectorFn<E extends Element> = (parentElement: Element) => E[];
+
 export type InteractorSpecification<E extends Element, F extends Filters<E>, A extends Actions<E>> = {
   /**
    * The CSS selector that this interactor uses to find matching elements
    */
-  selector?: string;
+  selector?: string | SelectorFn<E>;
   actions?: A;
   filters?: F;
   /**
@@ -209,7 +211,7 @@ export type FilterParams<E extends Element, F extends Filters<E>> = keyof F exte
  * @typeParam A the actions of this interactor, this is usually inferred from the specification
  */
 export interface InteractorConstructor<E extends Element, FP extends FilterParams<any, any>, FM extends FilterMethods<any, any>, AM extends ActionMethods<any, any>> {
-  selector(value: string): InteractorConstructor<E, FP, FM, AM>;
+  selector(value: string | SelectorFn<E>): InteractorConstructor<E, FP, FM, AM>;
   locator(value: LocatorFn<E>): InteractorConstructor<E, FP, FM, AM>;
   filters<FR extends Filters<E>>(filters: FR): InteractorConstructor<E, MergeObjects<FP, FilterParams<E, FR>>, MergeObjects<FM, FilterMethods<E, FR>>, AM>;
   actions<AR extends Actions<E>>(actions: AR): InteractorConstructor<E, FP, FM, MergeObjects<AM, ActionMethods<E, AR>>>;

--- a/packages/core/test/selector.test.ts
+++ b/packages/core/test/selector.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from 'mocha';
+import expect from 'expect';
+import { dom } from './helpers';
+
+import { createInteractor } from '../src';
+
+describe('selector', () => {
+  it('can use string as selector', async () => {
+    let Paragraph = createInteractor('p')
+      .selector('p')
+      .locator((e) => e.id);
+
+    dom(`
+      <p id="foo-id">Foo</p>
+      <p id="bar-id">Bar</p>
+    `);
+
+    await expect(Paragraph('foo-id').exists()).resolves.toBeUndefined();
+    await expect(Paragraph('bar-id').exists()).resolves.toBeUndefined();
+    await expect(Paragraph('quox-id').exists()).rejects.toHaveProperty('message', [
+      'did not find p "quox-id", did you mean one of:', '',
+      '┃ p          ┃',
+      '┣━━━━━━━━━━━━┫',
+      '┃ ⨯ "foo-id" ┃',
+      '┃ ⨯ "bar-id" ┃',
+    ].join('\n'));
+  });
+
+  it('can use function as selector', async () => {
+    let Paragraph = createInteractor('p')
+      .selector((parentElement) => Array.from(parentElement.querySelectorAll('p')))
+      .locator((e) => e.id);
+
+    dom(`
+      <p id="foo-id">Foo</p>
+      <p id="bar-id">Bar</p>
+    `);
+
+    await expect(Paragraph('foo-id').exists()).resolves.toBeUndefined();
+    await expect(Paragraph('bar-id').exists()).resolves.toBeUndefined();
+    await expect(Paragraph('quox-id').exists()).rejects.toHaveProperty('message', [
+      'did not find p "quox-id", did you mean one of:', '',
+      '┃ p          ┃',
+      '┣━━━━━━━━━━━━┫',
+      '┃ ⨯ "foo-id" ┃',
+      '┃ ⨯ "bar-id" ┃',
+    ].join('\n'));
+  });
+});


### PR DESCRIPTION
## Motivation

Most interactors use CSS selectors to locate the pertinent elements on the page. However, there are some interactors where it would be great if we could call a method to return the elements. An example would be a `Label` interactor, which would operate on the labels associated on a field. We would want to implement the interactor like this:

```js
const Label = HTML.extend('label').selector((e) => e.labels));
```

Another example is the keyboard interactor, which would really like to use `document.activeElement` as its selector.

Adding this option makes interactors even more powerful, since they are no longer constrained to just CSS selectors.

## Approach

Optionally, selector can take a function which gets as its argument the parent element, and must return a list of elements of the appropriate type.

### Alternate Designs

None

### Possible Drawbacks or Risks

Adds additional complexity