### PR TITLE
Try out new preview action

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -11,13 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'preview')
     steps:
-    - uses: actions/checkout@v1
-    - name: Publish PR Preview
-      uses: thefrontside/actions/publish-pr-preview@v1.4
+    - uses: actions/checkout@v2
       with:
-        before_all: yarn prepack:all
-        npm_publish: yarn publish
-        ignore: website
+        fetch-depth: 0
+    - uses: actions/setup-node@v2
+      with:
+        registry-url: https://registry.npmjs.org
+    - name: Publish PR Preview
+      uses: thefrontside/actions/publish-pr-preview@main
+      with:
+        INSTALL_SCRIPT: yarn install && yarn prepack:all
       env:
         GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Motivation

Rewrote preview action in node and so we're going to try it out here first. `effection` uses covector and `bigtest` doesn't have a lot of PRs so this repo seemed most appropriate.

## Approach

Calling the preview action directly from the `main` branch and updated the workflow accordingly. [README](https://github.com/thefrontside/actions/blob/main/publish-pr-preview/README.md) of the new action shows how the workflow should be configured.

## Learning
See PR of the refactor [here](https://github.com/thefrontside/actions/pull/65).