### PR TITLE
Locators as delegation

### DIFF
--- a/.changeset/nine-nails-brake.md
+++ b/.changeset/nine-nails-brake.md
@@ -1,0 +1,5 @@
+---
+"@interactors/core": minor
+---
+
+Enable delegation to locator of an interactor if no filter given

--- a/packages/core/src/constructor.ts
+++ b/packages/core/src/constructor.ts
@@ -179,6 +179,11 @@ export function instantiateBaseInteractor<E extends Element, F extends Filters<E
         });
       });
     },
+
+    apply(parentElement: Element): string {
+      let element = [...options.ancestors, options].reduce(resolveUnique, parentElement);
+      return applyFilter(options.specification.locator || defaultLocator, element);
+    }
   }
 
   for (let [actionName, action] of Object.entries(options.specification.actions || {})) {

--- a/packages/core/src/specification.ts
+++ b/packages/core/src/specification.ts
@@ -101,6 +101,11 @@ export interface BaseInteractor<E extends Element, F extends FilterParams<any, a
    * ```
    */
   is(filters: F): ReadonlyInteraction<void>;
+
+  /**
+   * @hidden
+   */
+  apply: FilterFn<string, Element>;
 }
 
 /**

--- a/packages/core/test/filter-delegate.test.ts
+++ b/packages/core/test/filter-delegate.test.ts
@@ -62,6 +62,29 @@ describe('filters delegation', () => {
     await expect(Datepicker("Start Date").has({ month: "January" })).resolves.toBeUndefined();
   });
 
+  it('delegates filter to other interactor locator', async () => {
+    let Span = createInteractor('span').selector('span');
+
+    let Paragraph = createInteractor('p')
+      .selector('p')
+      .filters({ span: Span() });
+
+    dom(`
+      <p><span>Foo</span> Quox</p>
+      <p><span>Bar</span> Quox</p>
+    `);
+
+    await expect(Paragraph({ span: 'Foo' }).exists()).resolves.toBeUndefined();
+    await expect(Paragraph({ span: 'Bar' }).exists()).resolves.toBeUndefined();
+    await expect(Paragraph({ span: 'Quox' }).exists()).rejects.toHaveProperty('message', [
+      'did not find p with span "Quox", did you mean one of:', '',
+      '┃ span: "Quox" ┃',
+      '┣━━━━━━━━━━━━━━┫',
+      '┃ ⨯ "Foo"      ┃',
+      '┃ ⨯ "Bar"      ┃',
+    ].join('\n'));
+  });
+
   it('throws an error if the delegated element does not exist', async () => {
     dom(`
       <div class="datepicker">

--- a/packages/core/test/locator.test.ts
+++ b/packages/core/test/locator.test.ts
@@ -49,7 +49,7 @@ describe('locator', () => {
     ].join('\n'));
   });
 
-  it('can delegate locator to other interactor', async () => {
+  it('can delegate locator to other interactor filter', async () => {
     let Span = createInteractor('span').selector('span').filters({
       text: (e) => e.textContent || ""
     });
@@ -57,6 +57,29 @@ describe('locator', () => {
     let Paragraph = createInteractor('p')
       .selector('p')
       .locator(Span().text());
+
+    dom(`
+      <p><span>Foo</span> Quox</p>
+      <p><span>Bar</span> Quox</p>
+    `);
+
+    await expect(Paragraph('Foo').exists()).resolves.toBeUndefined();
+    await expect(Paragraph('Bar').exists()).resolves.toBeUndefined();
+    await expect(Paragraph('Quox').exists()).rejects.toHaveProperty('message', [
+      'did not find p "Quox", did you mean one of:', '',
+      '┃ p       ┃',
+      '┣━━━━━━━━━┫',
+      '┃ ⨯ "Foo" ┃',
+      '┃ ⨯ "Bar" ┃',
+    ].join('\n'));
+  });
+
+  it('can delegate locator to other interactor locator', async () => {
+    let Span = createInteractor('span').selector('span');
+
+    let Paragraph = createInteractor('p')
+      .selector('p')
+      .locator(Span());
 
     dom(`
       <p><span>Foo</span> Quox</p>


### PR DESCRIPTION
This plugs a tiny omission in what we can delegate TO when using filter and locator delegation. Currently there are two things we can delegate TO, either a filter, like `TextField().value()` or an assertion such as `exists`, like `TextField().exists()`.

This could look like the following:

```js
let DatePicker = HTML.extend('datepicker')
  .selector('.datepicker')
  .filters({
    hasTextField: TextField().exists(),
    textFieldValue: TextField().value(),
  });
```

With this PR we also allow the actual interactor to be delegated to, which uses the interactors locator as the value:

```js
let DatePicker = HTML.extend('datepickerr')
  .selector('.datepicker')
  .filters({
    textFieldLabel: TextField(),
  });
```

Since the locator of `TextField` is its label, the `textFieldLabel` filter on `DatePicker` returns the label of the text field it contains.

This form can also be used for locator delegation:

```js
let DatePicker = HTML.extend('datepickerr')
  .selector('.datepicker')
  .locator(TextField())
```

This will cause `DatePicker("Birthday")` to search for an element with class "datepicker" which contains a text field with the label "Birthday".