### PR TITLE
Add navbar class

### DIFF
--- a/website/src/theme/Navbar/index.js
+++ b/website/src/theme/Navbar/index.js
@@ -15,7 +15,7 @@ function Navbar() {
   } = useThemeConfig();
 
   return (
-    <nav className={navBar[title]}>
+    <nav className={`navbar ${navBar[title]}`}>
       <LogoSelect currentProject={title} />
       <div>
         {items.map((item, i) => (


### PR DESCRIPTION
Merging #138 broke the documentation site, because the navbar must have a class of `navbar` for some reason

This is probably not the right way to fix this, but let's unbreak production first.