### PR TITLE
Remove READMEs from API docs

### DIFF
--- a/packages/html/typedoc.json
+++ b/packages/html/typedoc.json
@@ -3,5 +3,6 @@
   "name": "@interactors/html",
   "entryPoints": "src/index.ts",
   "includeVersion": true,
-  "excludePrivate": true
+  "excludePrivate": true,
+  "readme": "none"
 }

--- a/packages/material-ui/typedoc.json
+++ b/packages/material-ui/typedoc.json
@@ -4,5 +4,6 @@
   "entryPoints": "src/index.ts",
   "readme": "README.md",
   "includeVersion": true,
-  "excludePrivate": true
+  "excludePrivate": true,
+  "readme": "none"
 }


### PR DESCRIPTION
The package  READMEs don't really contain any useful information, it's better to just show the index page instead.