### PR TITLE
Update release workflow to run on ubuntu-20.04 and try out dockerfile fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,11 @@ on:
 jobs:
   publish-releases:
     name: Publish Releases
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
     - name: Publish Releases
-      uses: thefrontside/actions/synchronize-with-npm@v1.9
+      uses: thefrontside/actions/synchronize-with-npm@mk/fix-dockerfiles
       with:
         before_all: yarn prepack:all
         npm_publish: yarn publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish-releases:
     name: Publish Releases
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
     - name: Publish Releases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,11 @@ on:
 jobs:
   publish-releases:
     name: Publish Releases
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - name: Publish Releases
-      uses: thefrontside/actions/synchronize-with-npm@v1.6
+      uses: thefrontside/actions/synchronize-with-npm@v1.9
       with:
         before_all: yarn prepack:all
         npm_publish: yarn publish


### PR DESCRIPTION
## Motivation

https://github.com/thefrontside/interactors/actions/workflows/release.yml
https://github.com/alpinelinux/docker-alpine/issues/83

Release action stopped working because of a change in the node-12 alpine base image.

## Approach

- I updated the actions to install `python2` instead of `python`
- Hard set release workflow to run on `ubuntu-20.04` instead of `ubuntu-latest`
- Unfortunately this needs to be a multi-step process. We'll first need to merge this PR to test out the fix. Once we can confirm it's working, I can merge [actions #69](https://github.com/thefrontside/actions/pull/69), release `v1.9` and then update interactors repo to use the release action from `v1.9`