### PR TITLE
make className filter returns string for svg elements

### DIFF
--- a/.changeset/nervous-owls-buy.md
+++ b/.changeset/nervous-owls-buy.md
@@ -1,0 +1,5 @@
+---
+"@interactors/html": patch
+---
+
+make className filter returns string for svg elements

--- a/packages/html/src/html.ts
+++ b/packages/html/src/html.ts
@@ -2,14 +2,14 @@ import { click, createInteractor } from '@interactors/core';
 import { isVisible } from 'element-is-visible';
 
 const HTMLInteractor = createInteractor<HTMLElement>('element')
-  .selector(':not(svg), :not(svg *), foreignObject :not(svg):not(svg *)')
+  .selector('*')
   .locator(innerText)
   .filters({
     text: innerText,
     title: (element) => element.title,
     id: (element) => element.id,
     visible: { apply: isVisible, default: true },
-    className: (element) => element.className,
+    className: (element) => Array.from(element.classList).join(' '),
     classList: (element) => Array.from(element.classList),
     focused: (element) => element.ownerDocument.activeElement === element
   })

--- a/packages/html/test/html.test.ts
+++ b/packages/html/test/html.test.ts
@@ -16,19 +16,21 @@ describe('@interactors/html', () => {
       await expect(HTML('Blah').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
     });
 
-    it('finds html elements only', async () => {
+    it('finds svg elements by className', async () => {
       dom(`
+        <div>Foo</div>
         <svg id="spam">
           <circle class="circle" cx="40" cy="40" r="25" />
           <foreignObject>
-            <div>Baz</div>
+            <div>Bar</div>
           </foreignObject>
         </svg>
       `)
 
-      await expect(HTML('Baz').exists()).resolves.toBeUndefined();
-      await expect(HTML({ className: 'circle' }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
-      await expect(HTML({ id: 'spam' }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+      await expect(HTML('Foo').exists()).resolves.toBeUndefined();
+      await expect(HTML('Bar').exists()).resolves.toBeUndefined();
+      await expect(HTML({ className: 'circle' }).exists()).resolves.toBeUndefined();
+      await expect(HTML({ id: 'spam' }).exists()).resolves.toBeUndefined();
     })
 
     describe('.click', () => {


### PR DESCRIPTION
## Motivation

There was an issue https://github.com/thefrontside/bigtest/pull/930 when HTML interactor fails is trying to filter svg elements by `className`. Because `className` of SVGElement returns `SVGAnimatedString` instead `string`. So I tried to filter non-svg elements, but for an unknown reason jsdom behavior for query selectors is different to browser https://github.com/jsdom/jsdom/issues/3297

## Approach

Revert selector back for HTML interactor and change `className` filter to use `Array.from(element.classList).join(' ')` instead

### Alternate Designs

If jsdom doesn't have issue with selectors, we would be able to use this selector for HTML interactor

```typescript
(parentElement) => {
    let nonSVGElements = [...parentElement.querySelectorAll(":not(svg, svg *)")]
    parentElement.querySelectorAll('foreignObject')
      .forEach(foreignObject => nonSVGElements.push(...foreignObject.querySelectorAll(':not(svg, :scope svg *)')))
    return nonSVGElements as HTMLElement[]
  }
```
