### PR TITLE
Update release action to use `v1.9`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Publish Releases
-      uses: thefrontside/actions/synchronize-with-npm@mk/fix-dockerfiles
+      uses: thefrontside/actions/synchronize-with-npm@v1.9
       with:
         before_all: yarn prepack:all
         npm_publish: yarn publish


### PR DESCRIPTION
## Motivation

Follow up to [#152](https://github.com/thefrontside/interactors/pull/152).

## Approach

Action was broken. We made a fix for it. We tried out the fix directly from the branch. And now that we've confirmed it's working, we merged the fix and this PR is to update the workflow to call the action from the new release tag `v1.9`.
