### PR TITLE
Add code representation for interactions

### DIFF
--- a/.changeset/tidy-years-give.md
+++ b/.changeset/tidy-years-give.md
@@ -1,0 +1,7 @@
+---
+"@interactors/core": patch
+"@interactors/globals": patch
+"@interactors/with-cypress": patch
+---
+
+Add code representation for interactions

--- a/packages/core/src/constructor.ts
+++ b/packages/core/src/constructor.ts
@@ -155,7 +155,7 @@ export function instantiateInteractor<E extends Element, F extends Filters<E>, A
       return interaction(
         `run perform on ${description(options)}`,
         () => converge(() => fn(resolver(options))),
-        serializeActionOptions({ type: "interaction", actionName: "perform", options })
+        serializeActionOptions({ type: "action", actionName: "perform", options })
       )
     },
 
@@ -164,7 +164,7 @@ export function instantiateInteractor<E extends Element, F extends Filters<E>, A
         interaction(
           `${description(options)} asserts`,
           () => converge(() => { fn(resolver(options)) }),
-          serializeActionOptions({ type: "check", actionName: "assert", options }),
+          serializeActionOptions({ type: "assertion", actionName: "assert", options }),
         )
       );
     },
@@ -185,7 +185,7 @@ export function instantiateInteractor<E extends Element, F extends Filters<E>, A
               throw new FilterNotMatchingError(`${description(options)} does not match filters:\n\n${match.formatAsExpectations()}`);
             }
           }),
-          serializeActionOptions({ type: "check", actionName: "is", options, filters }),
+          serializeActionOptions({ type: "assertion", actionName: "is", options, filters }),
         )
       );
     },
@@ -202,7 +202,7 @@ export function instantiateInteractor<E extends Element, F extends Filters<E>, A
         interaction(
           `${description(options)} exists`,
           () => converge(() => { resolveNonEmpty(unsafeSyncResolveParent(options), options) }),
-          serializeActionOptions({ type: "check", actionName: "exists", options }),
+          serializeActionOptions({ type: "assertion", actionName: "exists", options }),
         ),
         (element) => findMatchesMatching(element, options).length > 0);
     },
@@ -212,7 +212,7 @@ export function instantiateInteractor<E extends Element, F extends Filters<E>, A
         interaction(
           `${description(options)} does not exist`,
           () => converge(() => { resolveEmpty(unsafeSyncResolveParent(options), options) }),
-          serializeActionOptions({ type: "check", actionName: "absent", options }),
+          serializeActionOptions({ type: "assertion", actionName: "absent", options }),
         ),
         (element) => findMatchesMatching(element, options).length === 0);
     },
@@ -234,7 +234,7 @@ export function instantiateInteractor<E extends Element, F extends Filters<E>, A
           return interaction(
             `${actionDescription} on ${description(options)}`,
             () => action(interactor as Interactor<E, FilterParams<E, F>> & ActionMethods<E, A>, ...args),
-            serializeActionOptions({ type: "interaction", actionName, options, args })
+            serializeActionOptions({ type: "action", actionName, options, args })
           );
         },
         configurable: true,
@@ -252,7 +252,7 @@ export function instantiateInteractor<E extends Element, F extends Filters<E>, A
             interaction(
               `${filterName} of ${description(options)}`,
               async () => converge(() => applyFilter(filter,  resolver(options))),
-              serializeActionOptions({ type: "check", actionName: filterName, options }),
+              serializeActionOptions({ type: "assertion", actionName: filterName, options }),
             ),
             (parentElement) => {
               let element = [...options.ancestors, options].reduce(resolveUnique, parentElement);

--- a/packages/core/src/constructor.ts
+++ b/packages/core/src/constructor.ts
@@ -26,7 +26,6 @@ import { Match } from './match';
 import { NoSuchElementError, NotAbsentError, AmbiguousElementError } from './errors';
 import { isMatcher } from './matcher';
 import { matching } from './matchers/matching';
-import { serializeActionOptions } from './serialize';
 
 const defaultLocator: FilterDefinition<string, Element> = (element) => element.textContent || "";
 const defaultSelector = 'div';
@@ -155,7 +154,7 @@ export function instantiateInteractor<E extends Element, F extends Filters<E>, A
       return interaction(
         `run perform on ${description(options)}`,
         () => converge(() => fn(resolver(options))),
-        serializeActionOptions({ type: "action", actionName: "perform", options })
+        { type: "action", actionName: "perform", options }
       )
     },
 
@@ -164,7 +163,7 @@ export function instantiateInteractor<E extends Element, F extends Filters<E>, A
         interaction(
           `${description(options)} asserts`,
           () => converge(() => { fn(resolver(options)) }),
-          serializeActionOptions({ type: "assertion", actionName: "assert", options }),
+          { type: "assertion", actionName: "assert", options },
         )
       );
     },
@@ -185,7 +184,7 @@ export function instantiateInteractor<E extends Element, F extends Filters<E>, A
               throw new FilterNotMatchingError(`${description(options)} does not match filters:\n\n${match.formatAsExpectations()}`);
             }
           }),
-          serializeActionOptions({ type: "assertion", actionName: "is", options, filters }),
+          { type: "assertion", actionName: "is", options, filters },
         )
       );
     },
@@ -202,7 +201,7 @@ export function instantiateInteractor<E extends Element, F extends Filters<E>, A
         interaction(
           `${description(options)} exists`,
           () => converge(() => { resolveNonEmpty(unsafeSyncResolveParent(options), options) }),
-          serializeActionOptions({ type: "assertion", actionName: "exists", options }),
+          { type: "assertion", actionName: "exists", options },
         ),
         (element) => findMatchesMatching(element, options).length > 0);
     },
@@ -212,7 +211,7 @@ export function instantiateInteractor<E extends Element, F extends Filters<E>, A
         interaction(
           `${description(options)} does not exist`,
           () => converge(() => { resolveEmpty(unsafeSyncResolveParent(options), options) }),
-          serializeActionOptions({ type: "assertion", actionName: "absent", options }),
+          { type: "assertion", actionName: "absent", options },
         ),
         (element) => findMatchesMatching(element, options).length === 0);
     },
@@ -234,7 +233,7 @@ export function instantiateInteractor<E extends Element, F extends Filters<E>, A
           return interaction(
             `${actionDescription} on ${description(options)}`,
             () => action(interactor as Interactor<E, FilterParams<E, F>> & ActionMethods<E, A>, ...args),
-            serializeActionOptions({ type: "action", actionName, options, args })
+            { type: "action", actionName, options, args }
           );
         },
         configurable: true,
@@ -252,7 +251,7 @@ export function instantiateInteractor<E extends Element, F extends Filters<E>, A
             interaction(
               `${filterName} of ${description(options)}`,
               async () => converge(() => applyFilter(filter,  resolver(options))),
-              serializeActionOptions({ type: "assertion", actionName: filterName, options }),
+              { type: "assertion", actionName: filterName, options },
             ),
             (parentElement) => {
               let element = [...options.ancestors, options].reduce(resolveUnique, parentElement);

--- a/packages/core/src/interaction.ts
+++ b/packages/core/src/interaction.ts
@@ -1,5 +1,6 @@
-import { ActionEvent, ActionOptions, globals } from '@interactors/globals';
-import type { FilterObject } from './specification';
+import { ActionEvent, globals } from '@interactors/globals';
+import { serializeActionOptions } from './serialize';
+import type { FilterObject, ActionOptions } from './specification';
 
 const interactionSymbol = Symbol.for('interaction');
 
@@ -69,7 +70,7 @@ export function interaction<T>(description: string, action: () => Promise<T>, op
   return createInteraction(
     description,
     globals.wrapAction(
-      Object.assign(new String(description), { description, action, options }) as string & ActionEvent<T>,
+      Object.assign(new String(description), { description, action, options: serializeActionOptions(options) }) as string & ActionEvent<T>,
       action,
       options.type
     )

--- a/packages/core/src/interaction.ts
+++ b/packages/core/src/interaction.ts
@@ -25,6 +25,10 @@ export interface Interaction<T> extends Promise<T> {
    */
   description: string;
   /**
+   * Return a code representation of the interaction
+   */
+  code: () => string;
+  /**
    * Return a serialized options of the interaction
    */
   options: SerializedActionOptions;
@@ -59,6 +63,7 @@ export function interaction<T>(description: string, action: () => Promise<T>, op
   return {
     description,
     options: serializedOptions,
+    code() { return serializedOptions.code },
     action: wrappedAction,
     [interactionSymbol]: true,
     [Symbol.toStringTag]: `[interaction ${description}]`,

--- a/packages/core/src/serialize.ts
+++ b/packages/core/src/serialize.ts
@@ -1,0 +1,52 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  ActionOptions as SerializedActionOptions,
+  InteractorOptions as SerializedInteractorOptions,
+} from "@interactors/globals";
+import { matcherCode } from "./matcher";
+import { ActionOptions, InteractorOptions } from "./specification";
+
+export function serializeInteractorOptions(options: InteractorOptions<any, any, any>): SerializedInteractorOptions {
+  let locator = matcherCode(options.locator?.value);
+  let filters: string[] = [];
+  for (let name in options.filter.all) {
+    filters.push(`"${name}": ${matcherCode(options.filter.all[name])}`);
+  }
+  let code = `${options.name}(${[locator, filters.length && `{ ${filters.join(", ")} }`].filter(Boolean).join(", ")})`;
+  return {
+    interactorName: options.name,
+    locator,
+    filter: options.filter.all,
+    code,
+  };
+}
+
+export function serializeActionOptions({
+  type,
+  actionName,
+  options,
+  ...restOptions
+}: ActionOptions): SerializedActionOptions {
+  let interactor = serializeInteractorOptions(options);
+  let ancestors = options.ancestors.map((ancestor) => serializeInteractorOptions(ancestor));
+  let args = "";
+  if ("filters" in restOptions) {
+    let filters: string[] = [];
+    for (let name in restOptions.filters) {
+      filters.push(`"${name}": ${matcherCode(restOptions.filters[name])}`);
+    }
+    args = `{ ${filters.join(", ")} }`;
+  } else if ("args" in restOptions) {
+    args = (restOptions.args ?? []).map((arg) => JSON.stringify(arg)).join(", ");
+  }
+  let code = `${[...ancestors, interactor]
+    .map(({ code }, index) => (index == 0 ? code : `${code})`))
+    .join(".find(")}.${actionName}(${args})`;
+  return {
+    interactor,
+    actionName,
+    type,
+    args: "filters" in restOptions ? [restOptions.filters] : "args" in restOptions ? restOptions.args : undefined,
+    code,
+  };
+}

--- a/packages/core/src/serialize.ts
+++ b/packages/core/src/serialize.ts
@@ -3,6 +3,7 @@ import {
   ActionOptions as SerializedActionOptions,
   InteractorOptions as SerializedInteractorOptions,
 } from "@interactors/globals";
+import { pascalCase } from "change-case";
 import { matcherCode } from "./matcher";
 import { ActionOptions, InteractorOptions } from "./specification";
 
@@ -13,8 +14,9 @@ export function serializeInteractorOptions(options: InteractorOptions<any, any, 
     filter: options.filter.all,
     locator,
     get code() {
+      let interactorName = pascalCase(options.name);
       let filters = Object.entries(options.filter.all).map(([name, filter]) => `"${name}": ${matcherCode(filter)}`);
-      return `${options.name}(${[locator, filters.length && `{ ${filters.join(", ")} }`].filter(Boolean).join(", ")})`
+      return `${interactorName}(${[locator, filters.length && `{ ${filters.join(", ")} }`].filter(Boolean).join(", ")})`;
     },
   };
 }
@@ -34,14 +36,14 @@ export function serializeActionOptions({
     args: "filters" in restOptions ? [restOptions.filters] : "args" in restOptions ? restOptions.args : undefined,
     get code() {
       let args = "";
-  if ("filters" in restOptions) {
-    let filters = Object.entries(restOptions.filters ?? {}).map(
-      ([name, filter]) => `"${name}": ${matcherCode(filter)}`
-    );
-    args = `{ ${filters.join(", ")} }`;
-  } else if ("args" in restOptions) {
-    args = (restOptions.args ?? []).map((arg) => JSON.stringify(arg)).join(", ");
-  }
+      if ("filters" in restOptions) {
+        let filters = Object.entries(restOptions.filters ?? {}).map(
+          ([name, filter]) => `"${name}": ${matcherCode(filter)}`
+        );
+        args = `{ ${filters.join(", ")} }`;
+      } else if ("args" in restOptions) {
+        args = (restOptions.args ?? []).map((arg) => JSON.stringify(arg)).join(", ");
+      }
       return `${[...ancestors, interactor]
         .map(({ code }, index) => (index == 0 ? code : `${code})`))
         .join(".find(")}.${actionName}(${args})`;

--- a/packages/core/src/serialize.ts
+++ b/packages/core/src/serialize.ts
@@ -8,16 +8,14 @@ import { ActionOptions, InteractorOptions } from "./specification";
 
 export function serializeInteractorOptions(options: InteractorOptions<any, any, any>): SerializedInteractorOptions {
   let locator = matcherCode(options.locator?.value);
-  let filters: string[] = [];
-  for (let name in options.filter.all) {
-    filters.push(`"${name}": ${matcherCode(options.filter.all[name])}`);
-  }
-  let code = `${options.name}(${[locator, filters.length && `{ ${filters.join(", ")} }`].filter(Boolean).join(", ")})`;
   return {
     interactorName: options.name,
-    locator,
     filter: options.filter.all,
-    code,
+    locator,
+    get code() {
+      let filters = Object.entries(options.filter.all).map(([name, filter]) => `"${name}": ${matcherCode(filter)}`);
+      return `${options.name}(${[locator, filters.length && `{ ${filters.join(", ")} }`].filter(Boolean).join(", ")})`
+    },
   };
 }
 
@@ -29,24 +27,24 @@ export function serializeActionOptions({
 }: ActionOptions): SerializedActionOptions {
   let interactor = serializeInteractorOptions(options);
   let ancestors = options.ancestors.map((ancestor) => serializeInteractorOptions(ancestor));
-  let args = "";
-  if ("filters" in restOptions) {
-    let filters: string[] = [];
-    for (let name in restOptions.filters) {
-      filters.push(`"${name}": ${matcherCode(restOptions.filters[name])}`);
-    }
-    args = `{ ${filters.join(", ")} }`;
-  } else if ("args" in restOptions) {
-    args = (restOptions.args ?? []).map((arg) => JSON.stringify(arg)).join(", ");
-  }
-  let code = `${[...ancestors, interactor]
-    .map(({ code }, index) => (index == 0 ? code : `${code})`))
-    .join(".find(")}.${actionName}(${args})`;
   return {
     interactor,
     actionName,
     type,
     args: "filters" in restOptions ? [restOptions.filters] : "args" in restOptions ? restOptions.args : undefined,
-    code,
+    get code() {
+      let args = "";
+  if ("filters" in restOptions) {
+    let filters = Object.entries(restOptions.filters ?? {}).map(
+      ([name, filter]) => `"${name}": ${matcherCode(filter)}`
+    );
+    args = `{ ${filters.join(", ")} }`;
+  } else if ("args" in restOptions) {
+    args = (restOptions.args ?? []).map((arg) => JSON.stringify(arg)).join(", ");
+  }
+      return `${[...ancestors, interactor]
+        .map(({ code }, index) => (index == 0 ? code : `${code})`))
+        .join(".find(")}.${actionName}(${args})`;
+    },
   };
 }

--- a/packages/core/src/specification.ts
+++ b/packages/core/src/specification.ts
@@ -246,3 +246,15 @@ export type InteractorOptions<E extends Element, F extends Filters<E>, A extends
   filter: FilterSet<E, F>;
   ancestors: InteractorOptions<any, any, any>[];
 };
+
+export type ActionOptions = {
+  type: "interaction";
+  actionName: string;
+  options: InteractorOptions<any, any, any>;
+  args?: unknown[];
+} | {
+  type: "check";
+  actionName: string;
+  options: InteractorOptions<any, any, any>;
+  filters?: FilterParams<any, any>;
+}

--- a/packages/core/src/specification.ts
+++ b/packages/core/src/specification.ts
@@ -248,12 +248,12 @@ export type InteractorOptions<E extends Element, F extends Filters<E>, A extends
 };
 
 export type ActionOptions = {
-  type: "interaction";
+  type: "action";
   actionName: string;
   options: InteractorOptions<any, any, any>;
   args?: unknown[];
 } | {
-  type: "check";
+  type: "assertion";
   actionName: string;
   options: InteractorOptions<any, any, any>;
   filters?: FilterParams<any, any>;

--- a/packages/core/src/specification.ts
+++ b/packages/core/src/specification.ts
@@ -225,6 +225,7 @@ export interface InteractorConstructor<E extends Element, FP extends FilterParam
    *
    * ``` typescript
    * Link('Home');
+   * Link(/^home/i);
    * ```
    *
    * Or with a locator and options:
@@ -236,7 +237,7 @@ export interface InteractorConstructor<E extends Element, FP extends FilterParam
    * @param value The locator value, which should match the value of applying the locator function defined in the {@link InteractorSpecification} to the element.
    * @param filters An object describing a set of filters to apply, which should match the value of applying the filters defined in the {@link InteractorSpecification} to the element.
    */
-  (value: MaybeMatcher<string>, filters?: FP): Interactor<E, FP> & FM & AM;
+  (value: MaybeMatcher<string> | RegExp, filters?: FP): Interactor<E, FP> & FM & AM;
 }
 
 export type InteractorOptions<E extends Element, F extends Filters<E>, A extends Actions<E, Interactor<E, EmptyObject>>> = {

--- a/packages/core/test/extend.test.ts
+++ b/packages/core/test/extend.test.ts
@@ -2,40 +2,7 @@ import { describe, it } from 'mocha';
 import expect from 'expect';
 import { dom } from './helpers';
 
-import { createInteractor } from '../src/index';
-
-const HTML = createInteractor<HTMLElement>('element')
-  .filters({
-    title: (element) => element.title,
-  })
-  .actions({
-    click: ({ perform }) => perform(element => { element.click() }),
-  });
-
-const Link = HTML.extend<HTMLLinkElement>('link')
-  .selector('a')
-  .filters({
-    href: (element) => element.href,
-  })
-  .actions({
-    setHref: ({ perform }, value: string) => perform((element) => { element.href = value })
-  })
-
-const Thing = HTML.extend<HTMLLinkElement>('div')
-  .selector('div')
-  .filters({
-    title: (element) => parseInt(element.dataset.title || '0'),
-  })
-  .actions({
-    click(interactor, value: number) {
-      return interactor.perform((element) => {
-        element.dataset.title = value.toString();
-      });
-    }
-  })
-
-const Header = createInteractor('header')
-  .selector('h1,h2,h3,h4,h5,h6')
+import { Header, Link, Thing, HTML } from './fixtures';
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 //@ts-ignore

--- a/packages/core/test/filter-delegate.test.ts
+++ b/packages/core/test/filter-delegate.test.ts
@@ -3,37 +3,7 @@ import expect from 'expect';
 import { dom } from './helpers';
 
 import { createInteractor } from '../src/index';
-
-const Header = createInteractor('header')
-  .filters({
-    text: (e) => e.textContent
-  })
-  .selector('h1,h2,h3,h4,h5,h6')
-
-const Calendar = createInteractor<HTMLElement>("calendar")
-  .selector("div.calendar")
-
-const TextField = createInteractor<HTMLInputElement>('text field')
-  .selector('input')
-  .filters({
-    placeholder: element => element.placeholder,
-  })
-  .actions({
-    click: ({ perform }) => perform((e) => e.click())
-  });
-
-const Datepicker = createInteractor<HTMLDivElement>("datepicker")
-  .selector("div.datepicker")
-  .locator(element => element.querySelector("label")?.textContent || "")
-  .filters({
-    open: Calendar().exists(),
-    month: Calendar().find(Header()).text(),
-  })
-  .actions({
-    toggle: async interactor => {
-      await interactor.find(TextField({ placeholder: "YYYY-MM-DD" })).click();
-    }
-  });
+import { Datepicker } from './fixtures';
 
 describe('filters delegation', () => {
   it('delegates the filter to a child element', async () => {

--- a/packages/core/test/fixtures.ts
+++ b/packages/core/test/fixtures.ts
@@ -1,0 +1,103 @@
+import { createInteractor } from "../src";
+
+export const Link = createInteractor<HTMLLinkElement>("link")
+  .selector("a")
+  .filters({
+    href: (element) => element.href,
+    title: (element) => element.title,
+  })
+  .actions({
+    click: ({ perform }) =>
+      perform((element) => {
+        element.click();
+      }),
+    setHref: ({ perform }, value: string) =>
+      perform((element) => {
+        element.href = value;
+      }),
+  });
+
+export const Header = createInteractor("header")
+  .selector("h1,h2,h3,h4,h5,h6")
+  .filters({
+    text: (e) => e.textContent,
+  });
+
+export const Div = createInteractor("div")
+  .selector("div")
+  .locator((element) => element.id || "");
+
+export const Details = createInteractor<HTMLDetailsElement>("details")
+  .selector("details")
+  .locator((element) => element.querySelector("summary")?.textContent || "");
+
+export const TextField = createInteractor<HTMLInputElement>("text field")
+  .selector("input")
+  .locator((element) => element.id)
+  .filters({
+    id: (element) => element.id,
+    placeholder: (element) => element.placeholder,
+    enabled: {
+      apply: (element) => !element.disabled,
+      default: true,
+    },
+    value: (element) => element.value,
+    focused: (element) => document.activeElement == element,
+    body: (element) => element.ownerDocument.body,
+    scroll: (element) => element.scrollIntoView,
+    rect: (element) => element.getBoundingClientRect(),
+  })
+  .actions({
+    fillIn: ({ perform }, value: string) =>
+      perform((element) => {
+        element.value = value;
+      }),
+    click: ({ perform }) =>
+      perform((element) => {
+        element.click();
+      }),
+  })
+  .actions({
+    append: async ({ value: currentValue, fillIn }, value: string) => fillIn(`${await currentValue()}${value}`),
+  });
+
+export const Calendar = createInteractor<HTMLElement>("calendar").selector("div.calendar");
+
+export const Datepicker = createInteractor<HTMLDivElement>("datepicker")
+  .selector("div.datepicker")
+  .locator((element) => element.querySelector("label")?.textContent || "")
+  .filters({
+    open: Calendar().exists(),
+    month: Calendar().find(Header()).text(),
+  })
+  .actions({
+    toggle: async (interactor) => {
+      await interactor.find(TextField({ placeholder: "YYYY-MM-DD" })).click();
+    },
+  });
+
+export const MainNav = createInteractor("main nav").selector("nav");
+
+export const HTML = createInteractor<HTMLElement>("element")
+  .filters({
+    title: (element) => element.title,
+  })
+  .actions({
+    click: ({ perform }) =>
+      perform((element) => {
+        element.click();
+      }),
+  });
+
+export const Thing = HTML.extend<HTMLLinkElement>("div")
+  .selector("div")
+  .filters({
+    title: (element) => parseInt(element.dataset.title || "0"),
+  })
+  .actions({
+    click(interactor, value: number) {
+      return interactor.perform((element) => {
+        element.dataset.title = value.toString();
+      });
+    },
+  });

--- a/packages/core/test/inspector.test.ts
+++ b/packages/core/test/inspector.test.ts
@@ -2,10 +2,8 @@ import { describe, it } from 'mocha';
 import expect from 'expect';
 import { dom } from './helpers';
 
-import { createInspector, createInteractor, including } from '../src/index';
-
-const Div = createInteractor('div').selector('div');
-const Link = createInteractor<HTMLAnchorElement>('link').selector('a').filters({ href: (e) => e.href });
+import { createInspector, including } from '../src';
+import { Div, Link } from './fixtures';
 
 describe('inspector', () => {
   it('.find', async () => {

--- a/packages/core/test/interactor.test.ts
+++ b/packages/core/test/interactor.test.ts
@@ -1,12 +1,7 @@
 import { describe, it } from 'mocha';
 import expect from 'expect';
 import { dom } from './helpers';
-
-import { createInteractor } from '../src';
-
-const MainNav = createInteractor<HTMLElement>('main nav').selector('nav');
-const Link = createInteractor<HTMLAnchorElement>('link').selector('a');
-const Heading = createInteractor<HTMLHeadingElement>('heading').selector('h1');
+import { Header, Link, MainNav } from './fixtures';
 
 describe('Interactor', () => {
   describe('instantiation', () => {
@@ -34,7 +29,7 @@ describe('Interactor', () => {
       `);
 
       await Link('Foo Bar').perform((e) => e.click());
-      await Heading('Hello!').exists();
+      await Header('Hello!').exists();
     });
 
     it('does nothing unless awaited', async () => {
@@ -49,7 +44,7 @@ describe('Interactor', () => {
       `);
 
       Link('Foo Bar').perform((e) => e.click());
-      await Heading('Hello!').absent();
+      await Header('Hello!').absent();
     });
 
     it('can return description of interaction', () => {

--- a/packages/core/test/matcher.test.ts
+++ b/packages/core/test/matcher.test.ts
@@ -2,13 +2,8 @@ import { describe, it } from 'mocha';
 import expect from 'expect';
 import { dom } from './helpers';
 
-import { createInteractor, Matcher } from '../src/index';
-
-const Link = createInteractor<HTMLLinkElement>('link')
-  .selector('a')
-  .filters({
-    title: (element) => element.title,
-  })
+import { Matcher } from '../src';
+import { Link } from './fixtures';
 
 function shouted(value: string): Matcher<string> {
   return {

--- a/packages/core/test/serialize.test.ts
+++ b/packages/core/test/serialize.test.ts
@@ -6,31 +6,33 @@ import { dom } from "./helpers";
 
 describe("serialize", () => {
   it("should serialize .exists()/.absent()", () => {
-    expect(TextField("Login").exists().options.code).toEqual('TextField("Login", { "enabled": true }).exists()');
-    expect(TextField("FooBar").absent().options.code).toEqual('TextField("FooBar", { "enabled": true }).absent()');
+    expect(TextField("Login").exists().code()).toEqual('TextField("Login", { "enabled": true }).exists()');
+    expect(TextField("FooBar").absent().code()).toEqual('TextField("FooBar", { "enabled": true }).absent()');
   });
 
   it("should serialize with additional filters", () => {
-    expect(TextField("Login", { id: "login", value: "jonas@example.com" }).exists().options.code).toEqual(
+    expect(TextField("Login", { id: "login", value: "jonas@example.com" }).exists().code()).toEqual(
       'TextField("Login", { "id": "login", "value": "jonas@example.com", "enabled": true }).exists()'
     );
-    expect(TextField("FooBar", { placeholder: "Login" }).absent().options.code).toEqual(
+    expect(TextField("FooBar", { placeholder: "Login" }).absent().code()).toEqual(
       'TextField("FooBar", { "placeholder": "Login", "enabled": true }).absent()'
     );
   });
 
   it("should serialize .is()/.has()", () => {
-    expect(TextField("Login").is({ focused: true }).options.code).toEqual(
+    expect(TextField("Login").is({ focused: true }).code()).toEqual(
       'TextField("Login", { "enabled": true }).is({ "focused": true })'
     );
-    expect(TextField("Login").has({ value: "jonas@example.com" }).options.code).toEqual(
+    expect(TextField("Login").has({ value: "jonas@example.com" }).code()).toEqual(
       'TextField("Login", { "enabled": true }).is({ "value": "jonas@example.com" })'
     );
   });
 
   it("should serialize matchers", () => {
     expect(
-      TextField(/^login.*/i, { enabled: or(false, true) }).has({ value: including("example.com") }).options.code
+      TextField(/^login.*/i, { enabled: or(false, true) })
+        .has({ value: including("example.com") })
+        .code()
     ).toEqual(
       'TextField(matching(/^login.*/i), { "enabled": or(false, true) }).is({ "value": including("example.com") })'
     );
@@ -40,46 +42,51 @@ describe("serialize", () => {
     let window = dom('<input id="Login" value="jonas@example.com" />');
 
     expect(
-      TextField("Login").has({
-        body: window.document.body,
-        scroll: function scrollIntoView() {},
-        rect: window.document.documentElement.getBoundingClientRect(),
-      }).options.code
+      TextField("Login")
+        .has({
+          body: window.document.body,
+          scroll: function scrollIntoView() {},
+          rect: window.document.documentElement.getBoundingClientRect(),
+        })
+        .code()
     ).toEqual(
       'TextField("Login", { "enabled": true }).is({ "body": {}, "scroll": undefined, "rect": {"x":0,"y":0,"bottom":0,"height":0,"left":0,"right":0,"top":0,"width":0} })'
     );
   });
 
   it("should serialize .perform/.assert", () => {
-    expect(TextField("Login").perform((element) => element.focus()).options.code).toEqual(
-      'TextField("Login", { "enabled": true }).perform()'
-    );
-    expect(TextField("Login").assert((element) => element.hasAttribute("aria-label")).options.code).toEqual(
-      'TextField("Login", { "enabled": true }).assert()'
-    );
+    expect(
+      TextField("Login")
+        .perform((element) => element.focus())
+        .code()
+    ).toEqual('TextField("Login", { "enabled": true }).perform()');
+    expect(
+      TextField("Login")
+        .assert((element) => element.hasAttribute("aria-label"))
+        .code()
+    ).toEqual('TextField("Login", { "enabled": true }).assert()');
   });
 
   it("should serialize actions", () => {
-    expect(TextField("Login").click().options.code).toEqual('TextField("Login", { "enabled": true }).click()');
-    expect(TextField("Login").fillIn("jonas@example.com").options.code).toEqual(
+    expect(TextField("Login").click().code()).toEqual('TextField("Login", { "enabled": true }).click()');
+    expect(TextField("Login").fillIn("jonas@example.com").code()).toEqual(
       'TextField("Login", { "enabled": true }).fillIn("jonas@example.com")'
     );
   });
 
   it("should serialize getters", () => {
-    expect(TextField("Login").placeholder().options.code).toEqual(
-      'TextField("Login", { "enabled": true }).placeholder()'
-    );
+    expect(TextField("Login").placeholder().code()).toEqual('TextField("Login", { "enabled": true }).placeholder()');
   });
 
   it("should serialize interaction with .find()", () => {
-    expect(HTML().find(TextField("Login")).exists().options.code).toEqual(
+    expect(HTML().find(TextField("Login")).exists().code()).toEqual(
       'Element().find(TextField("Login", { "enabled": true })).exists()'
     );
     expect(
       HTML("Foo")
         .find(HTML("Bar").find(HTML("Spam")))
-        .exists().options.code
+        .exists()
+        .code()
     ).toEqual('Element("Foo").find(Element("Bar")).find(Element("Spam")).exists()');
   });
 });

--- a/packages/globals/src/globals.ts
+++ b/packages/globals/src/globals.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { KeyboardLayout } from "./keyboard-layout";
 
-export type ActionType = "interaction" | "check";
+export type InteractionType = "action" | "assertion";
 
 interface Globals {
   readonly document: Document;
@@ -23,7 +23,7 @@ export type InteractorOptions = {
 export type ActionOptions = {
   interactor: InteractorOptions;
   actionName: string;
-  type: ActionType;
+  type: InteractionType;
   code: string;
   args?: unknown[];
 };
@@ -36,7 +36,7 @@ export interface ActionEvent<T> {
 
 export type ActionWrapper<T = any> =
   | ((event: ActionEvent<T>) => () => Promise<T>)
-  | ((description: string, action: () => Promise<T>, type: ActionType) => () => Promise<T>);
+  | ((description: string, action: () => Promise<T>, type: InteractionType) => () => Promise<T>);
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace, @typescript-eslint/prefer-namespace-keyword
@@ -121,7 +121,7 @@ export function setInteractorTimeout(ms: number): void {
 
 export function addActionWrapper<T>(wrapper: (event: ActionEvent<T>) => () => Promise<T>): () => boolean;
 export function addActionWrapper<T>(
-  wrapper: (description: string, action: () => Promise<T>, type: ActionType) => () => Promise<T>
+  wrapper: (description: string, action: () => Promise<T>, type: InteractionType) => () => Promise<T>
 ): () => boolean;
 export function addActionWrapper<T>(wrapper: ActionWrapper<T>): () => boolean {
   getGlobals().actionWrappers.add(wrapper);

--- a/packages/globals/test/globals.test.ts
+++ b/packages/globals/test/globals.test.ts
@@ -38,13 +38,35 @@ describe("@interactors/globals", () => {
   describe("wrapInteraction", () => {
     it("returns the same interaction without any change", () => {
       let action = async () => {};
-      expect(globals.wrapAction("plain action", action, "interaction")).toBe(action);
+      expect(
+        // @ts-expect-error `wrapAction` accepts string as first argument for back compatibility
+        globals.wrapAction({
+          description: "plain action",
+          action,
+          options: {
+            type: "interaction",
+            actionName: "plain",
+            code: "",
+            interactor: { interactorName: "Interactor", code: "" },
+          },
+        })
+      ).toBe(action);
     });
 
     it("applies defined interaction wrapper", async () => {
       let action = async () => "foo";
       let removeWrapper = addActionWrapper(() => async () => "bar");
-      let wrappedAction = globals.wrapAction("foo action", action, "interaction");
+      // @ts-expect-error `wrapAction` accepts string as first argument for back compatibility
+      let wrappedAction = globals.wrapAction({
+        description: "foo action",
+        action,
+        options: {
+          type: "interaction",
+          actionName: "foo",
+          code: "",
+          interactor: { interactorName: "Interactor", code: "" },
+        },
+      });
 
       removeWrapper();
 

--- a/packages/globals/test/globals.test.ts
+++ b/packages/globals/test/globals.test.ts
@@ -44,7 +44,7 @@ describe("@interactors/globals", () => {
           description: "plain action",
           action,
           options: {
-            type: "interaction",
+            type: "action",
             actionName: "plain",
             code: "",
             interactor: { interactorName: "Interactor", code: "" },
@@ -61,7 +61,7 @@ describe("@interactors/globals", () => {
         description: "foo action",
         action,
         options: {
-          type: "interaction",
+          type: "action",
           actionName: "foo",
           code: "",
           interactor: { interactorName: "Interactor", code: "" },

--- a/packages/html/src/button.ts
+++ b/packages/html/src/button.ts
@@ -4,7 +4,7 @@ function isButtonElement(element: HTMLInputElement | HTMLButtonElement): element
   return element.tagName === 'BUTTON';
 }
 
-const ButtonInteractor = HTML.extend<HTMLInputElement | HTMLButtonElement>('button')
+const ButtonInteractor = HTML.extend<HTMLInputElement | HTMLButtonElement>('Button')
   .selector('button,input[type=button],input[type=submit],input[type=reset],input[type=image]')
   .locator((element) => {
     if(isButtonElement(element)) {

--- a/packages/html/src/check-box.ts
+++ b/packages/html/src/check-box.ts
@@ -2,7 +2,7 @@ import { click } from '@interactors/core';
 import { isVisible } from 'element-is-visible';
 import { FormField } from './form-field';
 
-const CheckBoxInteractor = FormField.extend<HTMLInputElement>('check box')
+const CheckBoxInteractor = FormField.extend<HTMLInputElement>('CheckBox')
   .selector('input[type=checkbox]')
   .filters({
     checked: (element) => element.checked,

--- a/packages/html/src/details.ts
+++ b/packages/html/src/details.ts
@@ -1,8 +1,8 @@
 import { HTML } from './html';
 
-const SummaryInteractor = HTML.extend('summary').selector('summary');
+const SummaryInteractor = HTML.extend('Summary').selector('summary');
 
-const DetailsInteractor = HTML.extend<HTMLDetailsElement>('details')
+const DetailsInteractor = HTML.extend<HTMLDetailsElement>('Details')
   .locator(SummaryInteractor().text())
   .selector('details')
   .filters({

--- a/packages/html/src/field-set.ts
+++ b/packages/html/src/field-set.ts
@@ -2,7 +2,7 @@ import { HTML } from './html';
 
 const LegendInteractor = HTML.extend<HTMLLegendElement>('legend').selector('legend');
 
-const FieldSetInteractor = HTML.extend<HTMLHeadingElement>('fieldset')
+const FieldSetInteractor = HTML.extend<HTMLHeadingElement>('FieldSet')
   .selector('fieldset')
   .locator(LegendInteractor().text());
 

--- a/packages/html/src/form-field.ts
+++ b/packages/html/src/form-field.ts
@@ -6,7 +6,7 @@ function isElement<T extends keyof HTMLElementTagNameMap>(element: Element, tagN
   return element.tagName.toLowerCase() === tagName;
 }
 
-const LabelInteractor = HTML.extend<HTMLLabelElement>('label')
+const LabelInteractor = HTML.extend<HTMLLabelElement>('Label')
   .selector((element) => {
     if(isElement(element, 'input') || isElement(element, 'select') || isElement(element, 'textarea')) {
       return Array.from(element.labels || []);
@@ -15,7 +15,7 @@ const LabelInteractor = HTML.extend<HTMLLabelElement>('label')
     }
   })
 
-const FormFieldInteractor = HTML.extend<FieldTypes>('form field')
+const FormFieldInteractor = HTML.extend<FieldTypes>('FormField')
   .locator(LabelInteractor().text())
   .filters({
     valid: (element) => element.validity.valid,

--- a/packages/html/src/heading.ts
+++ b/packages/html/src/heading.ts
@@ -1,6 +1,6 @@
 import { HTML } from './html';
 
-const HeadingInteractor = HTML.extend<HTMLHeadingElement>('heading')
+const HeadingInteractor = HTML.extend<HTMLHeadingElement>('Heading')
   .selector('h1,h2,h3,h4,h5,h6')
   .filters({
     level: (element) => parseInt(element.tagName[1]),

--- a/packages/html/src/html.ts
+++ b/packages/html/src/html.ts
@@ -1,7 +1,7 @@
 import { click, createInteractor } from '@interactors/core';
 import { isVisible } from 'element-is-visible';
 
-const HTMLInteractor = createInteractor<HTMLElement>('element')
+const HTMLInteractor = createInteractor<HTMLElement>('HTML')
   .selector('*')
   .locator(innerText)
   .filters({

--- a/packages/html/src/link.ts
+++ b/packages/html/src/link.ts
@@ -1,6 +1,6 @@
 import { HTML } from './html';
 
-const LinkInteractor = HTML.extend<HTMLLinkElement>('link')
+const LinkInteractor = HTML.extend<HTMLLinkElement>('Link')
   .selector('a[href]')
   .filters({
     href: (element) => element.href,

--- a/packages/html/src/multi-select.ts
+++ b/packages/html/src/multi-select.ts
@@ -3,7 +3,7 @@ import { getSelect } from './get-select';
 import { HTML } from './html';
 import { FormField } from './form-field';
 
-const MultiSelectOption = HTML.extend<HTMLOptionElement>('option')
+const MultiSelectOption = HTML.extend<HTMLOptionElement>('MultiSelectOption')
   .selector('option')
   .locator((element) => element.label)
   .filters({
@@ -42,7 +42,7 @@ const MultiSelectOption = HTML.extend<HTMLOptionElement>('option')
     }),
   })
 
-const MultiSelectInteractor = FormField.extend<HTMLSelectElement>('select box')
+const MultiSelectInteractor = FormField.extend<HTMLSelectElement>('MultiSelect')
   .selector('select[multiple]')
   .filters({
     values: (element) => Array.from(element.selectedOptions).map((o) => o.label),

--- a/packages/html/src/page.ts
+++ b/packages/html/src/page.ts
@@ -1,6 +1,6 @@
 import { createInteractor } from '@interactors/core';
 
-const PageInteractor = createInteractor<HTMLHtmlElement>('page')
+const PageInteractor = createInteractor<HTMLHtmlElement>('Page')
   .selector(':root')
   .filters({
     title: (element) => element.ownerDocument.title,

--- a/packages/html/src/radio-button.ts
+++ b/packages/html/src/radio-button.ts
@@ -2,7 +2,7 @@ import { click } from '@interactors/core';
 import { isVisible } from 'element-is-visible';
 import { FormField } from './form-field';
 
-const RadioButtonInteractor = FormField.extend<HTMLInputElement>('radio button')
+const RadioButtonInteractor = FormField.extend<HTMLInputElement>('RadioButton')
   .selector('input[type=radio]')
   .filters({
     checked: (element) => element.checked,

--- a/packages/html/src/select.ts
+++ b/packages/html/src/select.ts
@@ -3,7 +3,7 @@ import { getSelect } from './get-select';
 import { HTML } from './html';
 import { FormField } from './form-field';
 
-const SelectOption = HTML.extend<HTMLOptionElement>('option')
+const SelectOption = HTML.extend<HTMLOptionElement>('SelectOption')
   .selector('option')
   .locator((element) => element.label)
   .filters({
@@ -24,7 +24,7 @@ const SelectOption = HTML.extend<HTMLOptionElement>('option')
     }),
   })
 
-const SelectInteractor = FormField.extend<HTMLSelectElement>('select box')
+const SelectInteractor = FormField.extend<HTMLSelectElement>('Select')
   .selector('select:not([multiple])')
   .filters({
     value: (element) => element.selectedOptions[0]?.label || '',

--- a/packages/html/src/text-field.ts
+++ b/packages/html/src/text-field.ts
@@ -6,7 +6,7 @@ const selector = 'textarea, input' + [
   'image', 'month', 'radio', 'range', 'reset', 'submit', 'time', 'datetime'
 ].map((t) => `:not([type=${t}])`).join('');
 
-const TextFieldInteractor = FormField.extend<HTMLInputElement | HTMLTextAreaElement>('text field')
+const TextFieldInteractor = FormField.extend<HTMLInputElement | HTMLTextAreaElement>('TextField')
   .selector(selector)
   .filters({
     value: (element) => element.value,

--- a/packages/html/test/page.test.ts
+++ b/packages/html/test/page.test.ts
@@ -13,7 +13,7 @@ describe('Page', () => {
 
       await expect(Page.has({ title: 'Hello World' })).resolves.toBeUndefined();
       await expect(Page.has({ title: 'Does Not Exist' })).rejects.toHaveProperty('message', [
-        'page does not match filters:', '',
+        'Page does not match filters:', '',
         '╒═ Filter:   title',
         '├─ Expected: "Does Not Exist"',
         '└─ Received: "Hello World"',
@@ -27,7 +27,7 @@ describe('Page', () => {
 
       await expect(Page.has({ url: 'about:blank' })).resolves.toBeUndefined();
       await expect(Page.has({ url: 'does-not-exist' })).rejects.toHaveProperty('message', [
-        'page does not match filters:', '',
+        'Page does not match filters:', '',
         '╒═ Filter:   url',
         '├─ Expected: "does-not-exist"',
         '└─ Received: "about:blank"',

--- a/packages/keyboard/src/keyboard.ts
+++ b/packages/keyboard/src/keyboard.ts
@@ -12,7 +12,7 @@ export type KeyOptions = {
   repeat?: boolean;
 }
 
-const KeyboardInteractor = createInteractor('keyboard')
+const KeyboardInteractor = createInteractor('Keyboard')
   .selector(':root')
   .actions({
     async press(interactor, options: KeyOptions = {}) {

--- a/packages/material-ui/src/accordion.ts
+++ b/packages/material-ui/src/accordion.ts
@@ -4,7 +4,7 @@ import { applyGetter, isDisabled, isHTMLElement } from "./helpers";
 const getSummary = (element: HTMLElement) => element.querySelector('[class*="MuiAccordionSummary-root"]');
 const isExpanded = (element: HTMLElement) => getSummary(element)?.getAttribute("aria-expanded") == "true";
 
-const AccordionSummary = HTML.extend<HTMLElement>("MUI Accordion Summary")
+const AccordionSummary = HTML.extend<HTMLElement>("MUIAccordionSummary")
   .selector('[class*="MuiAccordionSummary-root"]')
   .locator((element) => element.getAttribute("aria-label") ?? element.innerText)
   .filters({
@@ -15,7 +15,7 @@ const AccordionSummary = HTML.extend<HTMLElement>("MUI Accordion Summary")
     },
   });
 
-const AccordionInteractor = HTML.extend<HTMLElement>("MUI Accordion")
+const AccordionInteractor = HTML.extend<HTMLElement>("MUIAccordion")
   .selector('[class*="MuiAccordion-root"]')
   .locator((element) => {
     let summary = getSummary(element);

--- a/packages/material-ui/src/body.ts
+++ b/packages/material-ui/src/body.ts
@@ -1,6 +1,6 @@
 import { HTML } from "@interactors/html";
 
-export const Body = HTML.extend<HTMLBodyElement>("body")
+export const Body = HTML.extend<HTMLBodyElement>("Body")
   .selector("body")
   .actions({
     click: ({ perform }) =>

--- a/packages/material-ui/src/bottom-navigation.ts
+++ b/packages/material-ui/src/bottom-navigation.ts
@@ -1,7 +1,7 @@
 import { click, createInteractor } from "@interactors/core";
 import { isHTMLElement } from "./helpers";
 
-const BottomNavigationAction = createInteractor<HTMLButtonElement>("MUI BottomNavigationAction")
+const BottomNavigationAction = createInteractor<HTMLButtonElement>("MUIBottomNavigationAction")
   .selector('button[class*="MuiBottomNavigationAction-root"]')
   .locator((element) => {
     let label = element.querySelector('[class*="MuiBottomNavigationAction-label"]');
@@ -9,7 +9,7 @@ const BottomNavigationAction = createInteractor<HTMLButtonElement>("MUI BottomNa
   })
   .actions({ click: ({ perform }) => perform((element) => click(element)) });
 
-const BottomNavigationInteractor = createInteractor<HTMLElement>("MUI BottomNavigation")
+const BottomNavigationInteractor = createInteractor<HTMLElement>("MUIBottomNavigation")
   .selector('[class*="MuiBottomNavigation-root"]')
   .filters({
     value: (element) => {

--- a/packages/material-ui/src/button.ts
+++ b/packages/material-ui/src/button.ts
@@ -1,7 +1,7 @@
 import { HTML } from "@interactors/html";
 import { isDisabled } from "./helpers";
 
-const ButtonInteractor = HTML.extend<HTMLButtonElement | HTMLLinkElement>("MUI Button")
+const ButtonInteractor = HTML.extend<HTMLButtonElement | HTMLLinkElement>("MUIButton")
   .selector(
     ["button", "a[href]", '[role="button"]']
       .map((selector) => `${selector}[class*="MuiButton-root"], ${selector}[class*="MuiIconButton-root"]`)

--- a/packages/material-ui/src/calendar.ts
+++ b/packages/material-ui/src/calendar.ts
@@ -148,7 +148,7 @@ export function createCalendar(utils: DatePickerUtils) {
   });
 }
 
-const CalendarInteractor = createInteractor<HTMLElement>("MUI Calendar")
+const CalendarInteractor = createInteractor<HTMLElement>("MUICalendar")
   .selector('[class*="MuiPickersCalendar-transitionContainer"]')
   .locator(calendarLocator)
   .filters({

--- a/packages/material-ui/src/checkbox.ts
+++ b/packages/material-ui/src/checkbox.ts
@@ -1,6 +1,6 @@
 import { isVisible, click, CheckBox as BaseCheckbox, innerText } from "@interactors/html";
 
-const CheckboxInteractor = BaseCheckbox.extend("MUI Checkbox")
+const CheckboxInteractor = BaseCheckbox.extend("MUICheckbox")
   .selector('[class*="MuiCheckbox-root"] input[type=checkbox]')
   .locator((element) => element.labels ? innerText(Array.from(element.labels)[0]) : (element.getAttribute("aria-label") ?? ""))
   .filters({

--- a/packages/material-ui/src/date-field.ts
+++ b/packages/material-ui/src/date-field.ts
@@ -1,7 +1,7 @@
 import { TextField } from "@interactors/html";
 import { dispatchChange, setValue } from "./helpers";
 
-const DateFieldInteractor = TextField.extend<HTMLInputElement>("date field")
+const DateFieldInteractor = TextField.extend<HTMLInputElement>("DateField")
   .selector('input[type="date"]')
   .filters({
     date: (element) => element.valueAsDate,

--- a/packages/material-ui/src/datetime-field.ts
+++ b/packages/material-ui/src/datetime-field.ts
@@ -1,7 +1,7 @@
 import { TextField } from "@interactors/html";
 import { dispatchChange, setValue } from "./helpers";
 
-const DateTimeFieldInteractor = TextField.extend<HTMLInputElement>("datetime field")
+const DateTimeFieldInteractor = TextField.extend<HTMLInputElement>("DateTimeField")
   .selector('input[type="datetime-local"]')
   .filters({ timestamp: (element) => element.valueAsNumber })
   .actions({

--- a/packages/material-ui/src/dialog.ts
+++ b/packages/material-ui/src/dialog.ts
@@ -1,7 +1,7 @@
 import { click, HTML } from "@interactors/html";
 import { isHTMLElement } from "./helpers";
 
-const DialogInteractor = HTML.extend("MUI Dialog")
+const DialogInteractor = HTML.extend("MUIDialog")
   .selector('[class*="MuiDialog-root"][role="presentation"]:not([aria-hidden="true"])')
   .locator((element) => {
     let labelId = element.querySelector('[class*="MuiDialog-paper"][role="dialog"]')?.getAttribute("aria-labelledby");

--- a/packages/material-ui/src/fab.ts
+++ b/packages/material-ui/src/fab.ts
@@ -1,6 +1,6 @@
 import { Button } from "@interactors/html";
 
-const FabInteractor = Button.extend<HTMLButtonElement>("MUI Fab Button")
+const FabInteractor = Button.extend<HTMLButtonElement>("MUIFabButton")
   .selector('button[class*="MuiFab-root"]')
   .locator((element) => element.getAttribute("aria-label") ?? element.innerText)
   .filters({

--- a/packages/material-ui/src/form-control.ts
+++ b/packages/material-ui/src/form-control.ts
@@ -6,7 +6,7 @@ function getLabelElement(root: HTMLElement) {
   return isHTMLElement(label) ? label : null;
 }
 
-const FormControlInteractor = HTML.extend("MUI Form Control")
+const FormControlInteractor = HTML.extend("MUIFormControl")
   .selector('[class*="MuiFormControl-root"]')
   .locator((element) => getLabelElement(element)?.innerText ?? "")
   .filters({

--- a/packages/material-ui/src/link.ts
+++ b/packages/material-ui/src/link.ts
@@ -1,6 +1,6 @@
 import { Link as BaseLink } from "@interactors/html";
 
-const LinkInteractor = BaseLink.extend("MUI Link").selector(
+const LinkInteractor = BaseLink.extend("MUILink").selector(
   `${BaseLink().options.specification.selector as string}[class*="MuiLink-root"]`
 );
 

--- a/packages/material-ui/src/list.ts
+++ b/packages/material-ui/src/list.ts
@@ -1,10 +1,10 @@
 import { HTML } from "@interactors/html";
 
-const ListInteractor = HTML.extend<HTMLElement>("MUI List")
+const ListInteractor = HTML.extend<HTMLElement>("MUIList")
   .locator((element) => element.getAttribute("aria-label") ?? element.innerText)
   .selector('[class*="MuiList-root"]');
 
-const ListItemInteractor = HTML.extend<HTMLElement>("MUI ListItem")
+const ListItemInteractor = HTML.extend<HTMLElement>("MUIListItem")
   .selector('[class*="MuiListItem-root"]')
   .filters({
     disabled: {

--- a/packages/material-ui/src/menu.ts
+++ b/packages/material-ui/src/menu.ts
@@ -3,7 +3,7 @@ import { click, HTML } from "@interactors/html";
 import { Button } from "./button";
 import { applyGetter, isDisabled } from "./helpers";
 
-const MenuItemInteractor = HTML.extend<HTMLElement>("MUI MenuItem")
+const MenuItemInteractor = HTML.extend<HTMLElement>("MUIMenuItem")
   .selector('[class*="MuiMenuItem-root"][role="menuitem"]')
   .filters({
     disabled: {
@@ -13,13 +13,13 @@ const MenuItemInteractor = HTML.extend<HTMLElement>("MUI MenuItem")
   })
   .actions({ click: ({ perform }) => perform((element) => click(element)) });
 
-const MenuListInteractor = createInteractor<HTMLElement>("MUI MenuList")
+const MenuListInteractor = createInteractor<HTMLElement>("MUIMenuList")
   .selector(
     '[class*="MuiPopover-root"][role="presentation"] > [class*="MuiMenu-paper"] > [class*="MuiMenu-list"][role="menu"]'
   )
   .locator((element) => element.parentElement?.parentElement?.id ?? "");
 
-const MenuInteractor = Button.extend("MUI Menu")
+const MenuInteractor = Button.extend("MUIMenu")
   .selector(`${Button().options.specification.selector as string}[aria-haspopup="true"]`)
   .actions({
     open: async ({ perform }) => perform((element) => click(element)),

--- a/packages/material-ui/src/native-select.ts
+++ b/packages/material-ui/src/native-select.ts
@@ -2,10 +2,10 @@ import { Select, MultiSelect } from "@interactors/html";
 import { createFormFieldFilters } from "./form-field-filters";
 import { GetElementType } from "./types";
 
-const NativeSelectInteractor = Select.extend("MUI Native Select").filters(
+const NativeSelectInteractor = Select.extend("MUINativeSelect").filters(
   createFormFieldFilters<GetElementType<typeof Select>>()
 );
-const NativeMultiSelectInteractor = MultiSelect.extend("MUI Native MultiSelect").filters(
+const NativeMultiSelectInteractor = MultiSelect.extend("MUINativeMultiSelect").filters(
   createFormFieldFilters<GetElementType<typeof Select>>()
 );
 

--- a/packages/material-ui/src/popover.ts
+++ b/packages/material-ui/src/popover.ts
@@ -1,7 +1,7 @@
 import { HTML } from "@interactors/html";
 import { isHTMLElement } from "./helpers";
 
-const PopoverInteractor = HTML.extend("MUI Popover")
+const PopoverInteractor = HTML.extend("MUIPopover")
   .selector('[class*="MuiPopover-root"][role="presentation"]')
   .actions({
     close: ({ perform }) =>

--- a/packages/material-ui/src/radio.ts
+++ b/packages/material-ui/src/radio.ts
@@ -2,7 +2,7 @@ import { isVisible } from "@interactors/core";
 import { RadioButton } from "@interactors/html";
 import { isHTMLElement } from "./helpers";
 
-const RadioInteractor = RadioButton.extend("radio")
+const RadioInteractor = RadioButton.extend("Radio")
   .selector('[class*="MuiRadio-root"] input[type=radio]')
   .filters({
     visible: {

--- a/packages/material-ui/src/select.ts
+++ b/packages/material-ui/src/select.ts
@@ -3,7 +3,7 @@ import { click, HTML } from "@interactors/html";
 import { createFormFieldFilters } from "./form-field-filters";
 import { isDefined, isHTMLElement, delay, dispatchMouseDown, getInputLabel, applyGetter, isDisabled } from "./helpers";
 
-export const SelectOption = HTML.extend<HTMLLIElement>("MUI Option")
+export const SelectOption = HTML.extend<HTMLLIElement>("MUISelectOption")
   .selector('li[role="option"]')
   .filters({
     selected: (element) => element.getAttribute("aria-selected") == "true",
@@ -16,7 +16,7 @@ export const SelectOption = HTML.extend<HTMLLIElement>("MUI Option")
     choose: ({ perform }) => perform((element) => click(element)),
   });
 
-const SelectOptionsList = createInteractor<HTMLElement>("MUI OptionsList")
+const SelectOptionsList = createInteractor<HTMLElement>("MUISelectOptionsList")
   .selector("ul")
   .locator((element) => element.getAttribute("aria-labelledby") ?? "");
 
@@ -68,7 +68,7 @@ async function openSelectOptionsList<T>(interactor: Interactor<HTMLInputElement,
   return labelId;
 }
 
-const BaseSelect = createInteractor<HTMLInputElement>("MUI BaseSelect")
+const BaseSelect = createInteractor<HTMLInputElement>("MUIBaseSelect")
   .selector('[class*="MuiSelect-root"] + input[class*="MuiSelect-nativeInput"]')
   .locator((element) => getInputLabel(element)?.innerText ?? "")
   .filters({
@@ -90,7 +90,7 @@ const BaseSelect = createInteractor<HTMLInputElement>("MUI BaseSelect")
       }),
   });
 
-const SelectInteractor = BaseSelect.extend("MUI Select")
+const SelectInteractor = BaseSelect.extend("MUISelect")
   .filters({ value: getValueText })
   .actions({
     choose: async (interactor, value: string) => {
@@ -101,7 +101,7 @@ const SelectInteractor = BaseSelect.extend("MUI Select")
     },
   });
 
-const MultiSelectInteractor = BaseSelect.extend("MUI MultiSelect")
+const MultiSelectInteractor = BaseSelect.extend("MUIMultiSelect")
   .filters({ values: getChipLabels })
   .actions({
     choose: async (interactor, value: string) => {

--- a/packages/material-ui/src/slider.ts
+++ b/packages/material-ui/src/slider.ts
@@ -20,7 +20,7 @@ function parseValue(stringValue?: string | null) {
   return Number.isNaN(value) ? undefined : value;
 }
 
-export const Thumb = HTML.extend<HTMLElement>("MUI Slider Thumb")
+export const Thumb = HTML.extend<HTMLElement>("MUISliderThumb")
   .locator((element) => element.getAttribute("aria-label") ?? element.getAttribute("aria-valuetext") ?? "")
   .selector('[role="slider"][class*="MuiSlider-thumb"]')
   .filters({
@@ -109,7 +109,7 @@ export const Thumb = HTML.extend<HTMLElement>("MUI Slider Thumb")
       }),
   });
 
-const SliderInteractor = HTML.extend("MUI Slider")
+const SliderInteractor = HTML.extend("MUISlider")
   .selector('[class*="MuiSlider-root"]')
   .locator((element) => {
     let thumb = getThumb(element);

--- a/packages/material-ui/src/snackbar.ts
+++ b/packages/material-ui/src/snackbar.ts
@@ -1,7 +1,7 @@
 import { HTML } from "@interactors/html";
 import { isHTMLElement } from "./helpers";
 
-const SnackbarInteractor = HTML.extend("MUI Snackbar")
+const SnackbarInteractor = HTML.extend("MUISnackbar")
   .selector('[class*="MuiSnackbar-root"]')
   .locator((element) => {
     let messageElement = element.querySelector('[class*="MuiSnackbarContent-message"]');

--- a/packages/material-ui/src/switch.ts
+++ b/packages/material-ui/src/switch.ts
@@ -1,6 +1,6 @@
 import { Checkbox } from "./checkbox";
 
-const SwitchInteractor = Checkbox.extend("MUI Switch").selector('[class*="MuiSwitch-input"]');
+const SwitchInteractor = Checkbox.extend("MUISwitch").selector('[class*="MuiSwitch-input"]');
 
 /**
  * Call this {@link InteractorConstructor} to initialize a switch {@link Interactor}.

--- a/packages/material-ui/src/tabs.ts
+++ b/packages/material-ui/src/tabs.ts
@@ -1,7 +1,7 @@
 import { HTML } from "@interactors/html";
 import { isDisabled, isHTMLElement } from "./helpers";
 
-const TabInteractor = HTML.extend<HTMLElement>("MUI Tab")
+const TabInteractor = HTML.extend<HTMLElement>("MUITab")
   .selector('[class*="MuiTab-root"][role="tab"]')
   .locator((element) => element.getAttribute("aria-label") ?? element.innerText)
   .filters({
@@ -12,7 +12,7 @@ const TabInteractor = HTML.extend<HTMLElement>("MUI Tab")
     },
   });
 
-const TabsInteractor = HTML.extend<HTMLElement>("MUI Tabs")
+const TabsInteractor = HTML.extend<HTMLElement>("MUITabs")
   .selector('[class*="MuiTabs-root"]')
   .locator(
     (element) =>

--- a/packages/material-ui/src/text-field.ts
+++ b/packages/material-ui/src/text-field.ts
@@ -3,7 +3,7 @@ import { createFormFieldFilters } from "./form-field-filters";
 import { isHTMLElement } from "./helpers";
 import { GetElementType } from "./types";
 
-const TextFieldInteractor = BaseTextField.extend("MUI TextField")
+const TextFieldInteractor = BaseTextField.extend("MUITextField")
   .selector(["input", "textarea"].map((tag) => `${tag}[class*="MuiInputBase-input"]`).join(", "))
   .locator((element) => {
     let label = element.labels?.[0] ?? element.parentElement?.previousElementSibling;

--- a/packages/material-ui/src/time-field.ts
+++ b/packages/material-ui/src/time-field.ts
@@ -1,7 +1,7 @@
 import { TextField } from "@interactors/html";
 import { dispatchChange, setValue } from "./helpers";
 
-const TimeFieldInteractor = TextField.extend<HTMLInputElement>("time field")
+const TimeFieldInteractor = TextField.extend<HTMLInputElement>("TimeField")
   .selector('input[type="time"]')
   .filters({
     date: (element) => element.valueAsDate,

--- a/packages/with-cypress/src/cypress.ts
+++ b/packages/with-cypress/src/cypress.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 /// <reference types="cypress" />
-import { setDocumentResolver, addActionWrapper } from '@interactors/globals';
+import { setDocumentResolver, addActionWrapper, ActionEvent } from '@interactors/globals';
 import { Interaction, isInteraction, ReadonlyInteraction } from '@interactors/core';
 
 declare global {
@@ -16,13 +16,13 @@ let cypressCommand: CypressCommand | null = null
 type CypressCommand = 'expect' | 'do'
 
 setDocumentResolver(() => cy.$$('body')[0].ownerDocument);
-addActionWrapper((description, action, type) =>
-  async () => {
-    if (type == 'interaction' && cypressCommand == 'expect')
-      throw new Error(`tried to ${description} in \`cy.expect\`, actions/perform should only be run in \`cy.do\``);
-    return action()
+addActionWrapper((event: ActionEvent<unknown>) => {
+  return async () => {
+    if (event.options.type == 'interaction' && cypressCommand == 'expect')
+      throw new Error(`tried to ${event.description} in \`cy.expect\`, actions/perform should only be run in \`cy.do\``);
+    return event.action()
   }
-);
+});
 
 function interact(interactions: Interaction<void>[], command: CypressCommand): void {
   interactions

--- a/packages/with-cypress/src/cypress.ts
+++ b/packages/with-cypress/src/cypress.ts
@@ -18,7 +18,7 @@ type CypressCommand = 'expect' | 'do'
 setDocumentResolver(() => cy.$$('body')[0].ownerDocument);
 addActionWrapper((event: ActionEvent<unknown>) => {
   return async () => {
-    if (event.options.type == 'interaction' && cypressCommand == 'expect')
+    if (event.options.type == 'action' && cypressCommand == 'expect')
       throw new Error(`tried to ${event.description} in \`cy.expect\`, actions/perform should only be run in \`cy.do\``);
     return event.action()
   }


### PR DESCRIPTION
## Motivation

The second step of providing code representation for interactions to be able to show them in [interactive stories](https://storybook.js.org/blog/interactive-stories-beta/).

## Approach

Pass an action event into an action wrapper

## Issues

- Interactor's name might have space characters or any other restricted symbols so code representation will look like this
`text field("Password", { "enabled": true }).value()`
- The same problem with action/filter names
- Action arguments simply stringifying through `JSON.stringify`
- Don't stringify functions that passed to `assert` and `perform` methods