### PR TITLE
Use effection for converge and interactions

### DIFF
--- a/.changeset/smart-flowers-confess.md
+++ b/.changeset/smart-flowers-confess.md
@@ -1,0 +1,8 @@
+---
+"@interactors/core": minor
+"@interactors/globals": minor
+"@interactors/material-ui": patch
+"@interactors/with-cypress": patch
+---
+
+Use effection for converge and interactions

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "resolutions": {
     "@definitelytyped/typescript-versions": "^0.0.40",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
-    "chromedriver": "95.0.0",
+    "chromedriver": "96.0.0",
     "typescript": "^4.1.3",
     "yargs-parser": "^13.1.2"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,7 @@
     "prepack:commonjs": "tsc --project ./tsconfig.build.json --outdir dist/cjs --module commonjs"
   },
   "dependencies": {
+    "@effection/core": "2.2.0",
     "@interactors/globals": "1.0.0-rc1.1",
     "@testing-library/dom": "^8.5.0",
     "@testing-library/user-event": "^13.2.1",

--- a/packages/core/src/converge.ts
+++ b/packages/core/src/converge.ts
@@ -1,11 +1,8 @@
+import { Operation, sleep } from '@effection/core';
 import { performance } from 'performance-api';
 import { globals } from '@interactors/globals'
 
-function wait(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-export async function converge<T>(fn: () => T): Promise<T> {
+export function* converge<T>(fn: () => T): Operation<T> {
   let startTime = performance.now();
   while(true) {
     try {
@@ -15,7 +12,7 @@ export async function converge<T>(fn: () => T): Promise<T> {
       if(diff > globals.interactorTimeout) {
         throw e;
       } else {
-        await wait(1);
+        yield sleep(1);
       }
     }
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 export { Interactor, InteractorConstructor, InteractorSpecification, EmptyObject, FilterMethods, ActionMethods } from './specification';
-export { Interaction, ReadonlyInteraction, isInteraction } from './interaction';
+export { Interaction, ActionInteraction, AssertionInteraction, isInteraction } from './interaction';
 export { createInteractor } from './create-interactor';
 export { createInspector } from './inspector'
 export { isVisible } from 'element-is-visible';

--- a/packages/core/src/interaction.ts
+++ b/packages/core/src/interaction.ts
@@ -46,7 +46,6 @@ export interface Interaction<E extends Element, T = void> extends Promise<T> {
   check?: () => Task<T>;
 
   halt: () => Promise<void>;
-  catchHalt: () => void;
 
   [interactionSymbol]: true;
 }
@@ -122,8 +121,10 @@ export function createInteraction<E extends Element, T, Q>(type: InteractionType
     action,
     check: type === 'assertion' ? action : undefined,
     code: () => serializedOptions.code(),
-    halt: () => action().halt(),
-    catchHalt: () => shouldCatchHalt = true,
+    halt: () => {
+      shouldCatchHalt = true
+      return action().halt()
+    },
     [interactionSymbol]: true,
     [Symbol.toStringTag]: `[interaction ${options.description}]`,
     [Symbol.operation]: operation,

--- a/packages/core/src/serialize.ts
+++ b/packages/core/src/serialize.ts
@@ -1,52 +1,54 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import {
-  ActionOptions as SerializedActionOptions,
-  InteractorOptions as SerializedInteractorOptions,
-} from "@interactors/globals";
+import { InteractionOptions as SerializedInteractionOptions, InteractionType } from "@interactors/globals";
 import { pascalCase } from "change-case";
+import { InteractionOptions } from "./interaction";
 import { matcherCode } from "./matcher";
-import { ActionOptions, InteractorOptions } from "./specification";
+import { InteractorOptions } from "./specification";
 
-export function serializeInteractorOptions(options: InteractorOptions<any, any, any>): SerializedInteractorOptions {
+export function serializeInteractorOptions(options: InteractorOptions<any, any, any>): {
+  interactor: string;
+  filter: { [name: string]: unknown };
+  locator: string;
+  code: () => string;
+} {
   let locator = matcherCode(options.locator?.value);
   return {
-    interactorName: options.name,
+    interactor: options.name,
     filter: options.filter.all,
     locator,
-    get code() {
+    code() {
       let interactorName = pascalCase(options.name);
       let filters = Object.entries(options.filter.all).map(([name, filter]) => `"${name}": ${matcherCode(filter)}`);
-      return `${interactorName}(${[locator, filters.length && `{ ${filters.join(", ")} }`].filter(Boolean).join(", ")})`;
+      return `${interactorName}(${[locator, filters.length && `{ ${filters.join(", ")} }`]
+        .filter(Boolean)
+        .join(", ")})`;
     },
   };
 }
 
-export function serializeActionOptions({
-  type,
-  actionName,
-  options,
-  ...restOptions
-}: ActionOptions): SerializedActionOptions {
+export function serializeInteractionOptions<E extends Element, T>(
+  type: InteractionType,
+  { name, interactor: { options }, args, filters }: InteractionOptions<E, T>
+): SerializedInteractionOptions {
   let interactor = serializeInteractorOptions(options);
   let ancestors = options.ancestors.map((ancestor) => serializeInteractorOptions(ancestor));
   return {
-    interactor,
-    actionName,
+    ...interactor,
+    ancestors,
+    name,
     type,
-    args: "filters" in restOptions ? [restOptions.filters] : "args" in restOptions ? restOptions.args : undefined,
-    get code() {
-      let args = "";
-      if ("filters" in restOptions) {
-        let filters = Object.entries(restOptions.filters ?? {}).map(
-          ([name, filter]) => `"${name}": ${matcherCode(filter)}`
-        );
-        args = `{ ${filters.join(", ")} }`;
-      } else if ("args" in restOptions) {
-        args = (restOptions.args ?? []).map((arg) => JSON.stringify(arg)).join(", ");
+    args: filters ? [filters] : args ? args : undefined,
+    code() {
+      let serializedArgs = "";
+      if (filters) {
+        let serializedFilters = Object.entries(filters).map(([name, filter]) => `"${name}": ${matcherCode(filter)}`);
+        serializedArgs = `{ ${serializedFilters.join(", ")} }`;
+      } else if (args) {
+        serializedArgs = args.map((arg) => JSON.stringify(arg)).join(", ");
       }
       return `${[...ancestors, interactor]
-        .map(({ code }, index) => (index == 0 ? code : `${code})`))
-        .join(".find(")}.${actionName}(${args})`;
+        .map(({ code }, index) => (index == 0 ? code() : `${code()})`))
+        .join(".find(")}.${name}(${serializedArgs})`;
     },
   };
 }

--- a/packages/core/src/specification.ts
+++ b/packages/core/src/specification.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { Operation } from '@effection/core';
 import { FilterSet } from './filter-set';
 import { Locator } from './locator';
-import { Interaction, ReadonlyInteraction } from './interaction';
+import { ActionInteraction, AssertionInteraction } from './interaction';
 import { MergeObjects } from './merge-objects';
 import { MaybeMatcher } from './matcher';
 
@@ -38,7 +39,7 @@ export interface Interactor<E extends Element, F extends FilterParams<any, any>>
    * await Link('Next').perform((e) => e.click());
    * ```
    */
-  perform(fn: (element: E) => void): Interaction<void>;
+  perform(fn: (element: E) => void): ActionInteraction<E, void>;
 
   /**
    * Perform a one-off assertion on the given interactor. Takes a function which
@@ -54,7 +55,7 @@ export interface Interactor<E extends Element, F extends FilterParams<any, any>>
    * await Link('Next').assert((e) => assert(e.tagName === 'A'));
    * ```
    */
-  assert(fn: (element: E) => void): ReadonlyInteraction<void>;
+  assert(fn: (element: E) => void): AssertionInteraction<E, void>;
 
   /**
    * An assertion which checks that an element matching the interactor exists.
@@ -66,7 +67,7 @@ export interface Interactor<E extends Element, F extends FilterParams<any, any>>
    * await Link('Next').exists();
    * ```
    */
-  exists(): ReadonlyInteraction<void> & FilterObject<boolean, Element>;
+  exists(): AssertionInteraction<E, void> & FilterObject<boolean, Element>;
 
   /**
    * An assertion which checks that an element matching the interactor does not
@@ -78,7 +79,7 @@ export interface Interactor<E extends Element, F extends FilterParams<any, any>>
    * await Link('Next').absent();
    * ```
    */
-  absent(): ReadonlyInteraction<void> & FilterObject<boolean, Element>;
+  absent(): AssertionInteraction<E, void> & FilterObject<boolean, Element>;
 
   /**
    * Checks that there is one element matching the interactor, and that this
@@ -91,7 +92,7 @@ export interface Interactor<E extends Element, F extends FilterParams<any, any>>
    * await Link('Home').has({ href: '/' })
    * ```
    */
-  has(filters: F): ReadonlyInteraction<void>;
+  has(filters: F): AssertionInteraction<E, void>;
 
   /**
    * Identical to {@link has}, but reads better with some filters.
@@ -102,7 +103,7 @@ export interface Interactor<E extends Element, F extends FilterParams<any, any>>
    * await CheckBox('Accept conditions').is({ checked: true })
    * ```
    */
-  is(filters: F): ReadonlyInteraction<void>;
+  is(filters: F): AssertionInteraction<E, void>;
 
   /**
    * Returns a copy of the given interactor which is scoped to this interactor.
@@ -128,7 +129,7 @@ export interface Interactor<E extends Element, F extends FilterParams<any, any>>
   apply: FilterFn<string, Element>;
 }
 
-export type ActionFn<E extends Element, I extends Interactor<E, any>> = (interactor: I, ...args: any[]) => Promise<unknown>;
+export type ActionFn<E extends Element, I extends Interactor<E, any>> = (interactor: I, ...args: any[]) => Operation<unknown>;
 
 export type FilterFn<T, E extends Element> = (element: E) => T;
 
@@ -162,15 +163,15 @@ export type InteractorSpecification<E extends Element, F extends Filters<E>, A e
 }
 
 export type ActionMethods<E extends Element, A extends Actions<E, I>, I extends Interactor<E, any>> = {
-  [P in keyof A]: A[P] extends ((interactor: I, ...args: infer TArgs) => Promise<infer TReturn>)
-    ? ((...args: TArgs) => Interaction<TReturn>)
+  [P in keyof A]: A[P] extends ((interactor: I, ...args: infer TArgs) => Operation<infer TReturn>)
+    ? ((...args: TArgs) => ActionInteraction<E, TReturn>)
     : never;
 }
 
 export type FilterMethods<E extends Element, F extends Filters<E>> = {
   [P in keyof F]:
-    F[P] extends FilterFn<infer TReturn, any> ? (() => Interaction<TReturn> & FilterObject<TReturn, Element>) :
-    F[P] extends FilterObject<infer TReturn, any> ? (() => Interaction<TReturn> & FilterObject<TReturn, Element>) :
+    F[P] extends FilterFn<infer TReturn, any> ? (() => AssertionInteraction<E, TReturn> & FilterObject<TReturn, Element>) :
+    F[P] extends FilterObject<infer TReturn, any> ? (() => AssertionInteraction<E, TReturn> & FilterObject<TReturn, Element>) :
     never;
 }
 
@@ -247,15 +248,3 @@ export type InteractorOptions<E extends Element, F extends Filters<E>, A extends
   filter: FilterSet<E, F>;
   ancestors: InteractorOptions<any, any, any>[];
 };
-
-export type ActionOptions = {
-  type: "action";
-  actionName: string;
-  options: InteractorOptions<any, any, any>;
-  args?: unknown[];
-} | {
-  type: "assertion";
-  actionName: string;
-  options: InteractorOptions<any, any, any>;
-  filters?: FilterParams<any, any>;
-}

--- a/packages/core/test/create-interactor.test.ts
+++ b/packages/core/test/create-interactor.test.ts
@@ -506,5 +506,11 @@ describe('createInteractor', () => {
       await expect(TextField({ value: 'jonas@' }).append('example.com')).resolves.toBeUndefined();
       await expect(TextField({ value: 'jonas@example.com' }).id()).resolves.toEqual('Email');
     });
+
+    it('should return function rather than execute it', async () => {
+      let window = dom('<input id="Login" value="jonas@example.com" />');
+
+      await expect(TextField('Login').attributeSetter()).resolves.toEqual(window.document.documentElement.setAttribute)
+    })
   })
 });

--- a/packages/core/test/fixtures.ts
+++ b/packages/core/test/fixtures.ts
@@ -42,9 +42,9 @@ export const TextField = createInteractor<HTMLInputElement>("text field")
       default: true,
     },
     value: (element) => element.value,
-    focused: (element) => document.activeElement == element,
+    focused: (element) => element.ownerDocument.activeElement == element,
     body: (element) => element.ownerDocument.body,
-    scroll: (element) => element.scrollIntoView,
+    attributeSetter: (element) => element.setAttribute,
     rect: (element) => element.getBoundingClientRect(),
   })
   .actions({
@@ -71,8 +71,8 @@ export const Datepicker = createInteractor<HTMLDivElement>("datepicker")
     month: Calendar().find(Header()).text(),
   })
   .actions({
-    toggle: async (interactor) => {
-      await interactor.find(TextField({ placeholder: "YYYY-MM-DD" })).click();
+    toggle: function* (interactor) {
+      yield interactor.find(TextField({ placeholder: "YYYY-MM-DD" })).click();
     },
   });
 

--- a/packages/core/test/helpers.ts
+++ b/packages/core/test/helpers.ts
@@ -1,13 +1,15 @@
 import { beforeEach } from "mocha";
 import { DOMWindow, JSDOM } from "jsdom";
-import { globals, setDocumentResolver, setInteractorTimeout } from "@interactors/globals";
+import { addInteractionWrapper, globals, setDocumentResolver, setInteractorTimeout } from "@interactors/globals";
 
 let jsdom: JSDOM;
+let removeWrapper: () => void;
 
 export function dom(html: string): DOMWindow {
   jsdom = new JSDOM(`<!doctype html><html><body>${html}</body></html>`, { runScripts: "dangerously" });
 
   setDocumentResolver(() => jsdom.window.document);
+  removeWrapper = addInteractionWrapper(async (perform) => perform());
 
   return jsdom.window;
 }
@@ -18,5 +20,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  removeWrapper?.();
   jsdom?.window?.close();
 });

--- a/packages/core/test/serialize.test.ts
+++ b/packages/core/test/serialize.test.ts
@@ -45,12 +45,12 @@ describe("serialize", () => {
       TextField("Login")
         .has({
           body: window.document.body,
-          scroll: function scrollIntoView() {},
+          attributeSetter: function attributeSetter() {},
           rect: window.document.documentElement.getBoundingClientRect(),
         })
         .code()
     ).toEqual(
-      'TextField("Login", { "enabled": true }).is({ "body": {}, "scroll": undefined, "rect": {"x":0,"y":0,"bottom":0,"height":0,"left":0,"right":0,"top":0,"width":0} })'
+      'TextField("Login", { "enabled": true }).is({ "body": {}, "attributeSetter": undefined, "rect": {"x":0,"y":0,"bottom":0,"height":0,"left":0,"right":0,"top":0,"width":0} })'
     );
   });
 

--- a/packages/globals/package.json
+++ b/packages/globals/package.json
@@ -37,5 +37,8 @@
   "volta": {
     "node": "14.17.5",
     "yarn": "1.22.11"
+  },
+  "dependencies": {
+    "@effection/core": "2.2.0"
   }
 }

--- a/packages/globals/src/globals.ts
+++ b/packages/globals/src/globals.ts
@@ -10,8 +10,7 @@ type Interaction<T = any> = Operation<T> & {
   options: InteractionOptions;
   interactor: unknown; // we can't type this any better here
   code: () => string;
-  catchHalt: () => void;
-  halt: () => void;
+  halt: () => Promise<void>;
 };
 
 interface Globals {

--- a/packages/globals/src/globals.ts
+++ b/packages/globals/src/globals.ts
@@ -1,42 +1,48 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import type { Operation } from "@effection/core";
 import { KeyboardLayout } from "./keyboard-layout";
 
 export type InteractionType = "action" | "assertion";
 
+type Interaction<T = any> = Operation<T> & {
+  type: InteractionType;
+  description: string;
+  options: InteractionOptions;
+  interactor: unknown; // we can't type this any better here
+  code: () => string;
+  catchHalt: () => void;
+  halt: () => void;
+};
+
 interface Globals {
   readonly document: Document;
-  readonly wrapAction: ActionWrapper;
-  readonly actionWrappers: Set<ActionWrapper>;
+  /**
+   * @deprecated Use `wrapInteraction` instead
+   */
+  readonly wrapAction: <T>(description: string, perform: () => Promise<T>, type: InteractionType) => Operation<T>;
+  readonly wrapInteraction: InteractionWrapper;
+  readonly interactionWrappers: Set<InteractionWrapper>;
   readonly interactorTimeout: number;
   readonly reset: () => void;
   readonly keyboardLayout: KeyboardLayout;
 }
 
 export type InteractorOptions = {
-  interactorName: string;
-  code: string;
+  interactor: string;
+  code: () => string;
   locator?: string;
   filter?: Record<string, unknown>;
+};
+
+export type InteractionOptions = InteractorOptions & {
+  name: string;
+  type: InteractionType;
+  code: () => string;
+  args?: unknown[];
   ancestors?: InteractorOptions[];
 };
 
-export type ActionOptions = {
-  interactor: InteractorOptions;
-  actionName: string;
-  type: InteractionType;
-  code: string;
-  args?: unknown[];
-};
-
-export interface ActionEvent<T> {
-  description: string;
-  action: () => Promise<T>;
-  options: ActionOptions;
-}
-
-export type ActionWrapper<T = any> =
-  | ((event: ActionEvent<T>) => () => Promise<T>)
-  | ((description: string, action: () => Promise<T>, type: InteractionType) => () => Promise<T>);
+export type InteractionWrapper<T = any> = (perform: () => Promise<T>, interaction: Interaction<T>) => Operation<T>;
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace, @typescript-eslint/prefer-namespace-keyword
@@ -47,6 +53,16 @@ declare global {
 }
 
 if (!globalThis.__interactors) {
+  let wrapInteraction = <T>(perform: () => Promise<T>, interaction: Interaction<T>): Operation<T> => {
+    return (scope) => {
+      let current = perform;
+      for (let wrapper of getGlobals().interactionWrappers) {
+        let operation = wrapper(current, interaction);
+        current = () => scope.run(operation);
+      }
+      return current;
+    };
+  };
   Object.defineProperty(globalThis, "__interactors", {
     value: Object.defineProperties(
       {},
@@ -62,24 +78,14 @@ if (!globalThis.__interactors) {
           configurable: true,
         },
         wrapAction: {
-          value: <T>(event: ActionEvent<T>): (() => Promise<T>) => {
-            let wrappedAction = event.action;
-            for (let wrapper of getGlobals().actionWrappers) {
-              wrappedAction = wrapper(
-                Object.assign(new String(event.description), {
-                  description: event.description,
-                  action: wrappedAction,
-                  options: event.options,
-                }) as string & ActionEvent<T>,
-                wrappedAction,
-                event.options.type
-              );
-            }
-            return wrappedAction;
-          },
+          value: wrapInteraction,
           enumerable: true,
         },
-        actionWrappers: {
+        wrapInteraction: {
+          value: wrapInteraction,
+          enumerable: true,
+        },
+        interactionWrappers: {
           value: new Set(),
         },
         interactorTimeout: {
@@ -101,7 +107,7 @@ if (!globalThis.__interactors) {
 
 const getGlobals = () => globalThis.__interactors as Globals;
 
-export const globals = getGlobals() as Omit<Globals, "actionWrappers">;
+export const globals = getGlobals();
 
 export function setDocumentResolver(resolver: () => Document): void {
   Object.defineProperty(getGlobals(), "document", {
@@ -119,14 +125,22 @@ export function setInteractorTimeout(ms: number): void {
   });
 }
 
-export function addActionWrapper<T>(wrapper: (event: ActionEvent<T>) => () => Promise<T>): () => boolean;
+/**
+ * @deprecated Use `addInteractionWrapper` instead
+ */
 export function addActionWrapper<T>(
-  wrapper: (description: string, action: () => Promise<T>, type: InteractionType) => () => Promise<T>
-): () => boolean;
-export function addActionWrapper<T>(wrapper: ActionWrapper<T>): () => boolean {
-  getGlobals().actionWrappers.add(wrapper);
+  wrapper: (description: string, perform: () => Promise<T>, type: InteractionType) => Operation<T>
+): () => boolean {
+  return addInteractionWrapper(
+    (perform: () => Promise<T>, interaction: Interaction<T>): Operation<T> =>
+      wrapper(interaction.description, perform, interaction.type)
+  );
+}
 
-  return () => getGlobals().actionWrappers.delete(wrapper);
+export function addInteractionWrapper<T>(wrapper: InteractionWrapper<T>): () => boolean {
+  getGlobals().interactionWrappers.add(wrapper);
+
+  return () => getGlobals().interactionWrappers.delete(wrapper);
 }
 
 export function setKeyboardLayout(layout: KeyboardLayout): void {

--- a/packages/globals/test/globals.test.ts
+++ b/packages/globals/test/globals.test.ts
@@ -48,7 +48,7 @@ describe("@interactors/globals", () => {
             description: "plain action",
             action,
             code: () => "",
-            halt: () => {},
+            halt: () => Promise.resolve(),
             options: {
               interactor: "Interactor",
               name: "plain",
@@ -72,7 +72,7 @@ describe("@interactors/globals", () => {
           description: "foo action",
           action,
           code: () => "",
-          halt: () => {},
+          halt: () => Promise.resolve(),
           options: {
             interactor: "Interactor",
             name: "foo",

--- a/packages/globals/test/globals.test.ts
+++ b/packages/globals/test/globals.test.ts
@@ -1,8 +1,9 @@
 import { describe, it } from "mocha";
 import expect from "expect";
 import { JSDOM } from "jsdom";
+import { Symbol } from "@effection/core";
 
-import { globals, setDocumentResolver, addActionWrapper, setInteractorTimeout } from "../src";
+import { globals, setDocumentResolver, addInteractionWrapper, setInteractorTimeout } from "../src";
 
 function makeDocument(body = ""): Document {
   return new JSDOM(`<!doctype html><html><body>${body}</body></html>`).window.document;
@@ -39,38 +40,51 @@ describe("@interactors/globals", () => {
     it("returns the same interaction without any change", () => {
       let action = async () => {};
       expect(
-        // @ts-expect-error `wrapAction` accepts string as first argument for back compatibility
-        globals.wrapAction({
-          description: "plain action",
+        (globals.wrapInteraction(
           action,
-          options: {
+          {
             type: "action",
-            actionName: "plain",
-            code: "",
-            interactor: { interactorName: "Interactor", code: "" },
-          },
-        })
+            interactor: "Interactor",
+            description: "plain action",
+            action,
+            code: () => "",
+            halt: () => {},
+            options: {
+              interactor: "Interactor",
+              name: "plain",
+              type: "action",
+              code: () => "",
+            },
+            [Symbol.operation]: Promise.resolve(),
+          }
+        ) as () => unknown)()
       ).toBe(action);
     });
 
     it("applies defined interaction wrapper", async () => {
       let action = async () => "foo";
-      let removeWrapper = addActionWrapper(() => async () => "bar");
-      // @ts-expect-error `wrapAction` accepts string as first argument for back compatibility
-      let wrappedAction = globals.wrapAction({
-        description: "foo action",
+      let removeWrapper = addInteractionWrapper(() => async () => "bar");
+      globals.wrapInteraction(
         action,
-        options: {
+        {
           type: "action",
-          actionName: "foo",
-          code: "",
-          interactor: { interactorName: "Interactor", code: "" },
+          interactor: "Interactor",
+          description: "foo action",
+          action,
+          code: () => "",
+          halt: () => {},
+          options: {
+            interactor: "Interactor",
+            name: "foo",
+            type: "action",
+            code: () => "",
+          },
+          [Symbol.operation]: Promise.resolve(),
         },
-      });
+      );
 
       removeWrapper();
-
-      expect(await wrappedAction()).toEqual("bar");
+      expect(globals.interactionWrappers.has(action)).toEqual(false);
     });
   });
 });

--- a/packages/material-ui/src/calendar.ts
+++ b/packages/material-ui/src/calendar.ts
@@ -44,7 +44,7 @@ export const getYear = (element: HTMLElement): number | undefined => {
 async function goToMonth(
   interactor: ReturnType<typeof Calendar>,
   targetMonth: string,
-  directionStep: () => Interaction<void>,
+  directionStep: () => Interaction<HTMLElement>,
   currentYear?: number
 ) {
   let currentMonth = await interactor.month();
@@ -171,12 +171,12 @@ const CalendarInteractor = createInteractor<HTMLElement>("MUICalendar")
 
       let directions = [() => interactor.prevMonth(), () => interactor.nextMonth()];
       directions = Math.round(Math.random()) ? directions : directions.reverse();
-      let directionStep = directions.shift() as () => Interaction<void>;
+      let directionStep = directions.shift() as () => Interaction<HTMLElement>;
 
       try {
         await goToMonth(interactor as ReturnType<typeof Calendar>, targetMonth, directionStep, currentYear);
       } catch (_) {
-        directionStep = directions.shift() as () => Interaction<void>;
+        directionStep = directions.shift() as () => Interaction<HTMLElement>;
         await goToMonth(interactor as ReturnType<typeof Calendar>, targetMonth, directionStep, currentYear);
       }
     },

--- a/packages/with-cypress/src/cypress.ts
+++ b/packages/with-cypress/src/cypress.ts
@@ -1,13 +1,13 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 /// <reference types="cypress" />
-import { setDocumentResolver, addActionWrapper, ActionEvent } from '@interactors/globals';
-import { Interaction, isInteraction, ReadonlyInteraction } from '@interactors/core';
+import { setDocumentResolver, addInteractionWrapper } from '@interactors/globals';
+import { Interaction, isInteraction, AssertionInteraction } from '@interactors/core';
 
 declare global {
   namespace Cypress {
     interface Chainable<Subject> {
-      do(interaction: Interaction<void> | Interaction<void>[]): Chainable<Subject>;
-      expect(interaction: ReadonlyInteraction<void> | ReadonlyInteraction<void>[]): Chainable<Subject>;
+      do(interaction: Interaction<Element> | Interaction<Element>[]): Chainable<Subject>;
+      expect(interaction: AssertionInteraction<Element> | AssertionInteraction<Element>[]): Chainable<Subject>;
     }
   }
 }
@@ -16,15 +16,15 @@ let cypressCommand: CypressCommand | null = null
 type CypressCommand = 'expect' | 'do'
 
 setDocumentResolver(() => cy.$$('body')[0].ownerDocument);
-addActionWrapper((event: ActionEvent<unknown>) => {
-  return async () => {
-    if (event.options.type == 'action' && cypressCommand == 'expect')
-      throw new Error(`tried to ${event.description} in \`cy.expect\`, actions/perform should only be run in \`cy.do\``);
-    return event.action()
+addInteractionWrapper((operation, interaction) =>
+  () => {
+    if (interaction.type == 'action' && cypressCommand == 'expect')
+      throw new Error(`tried to ${interaction.description} in \`cy.expect\`, actions/perform should only be run in \`cy.do\``);
+    return operation
   }
-});
+);
 
-function interact(interactions: Interaction<void>[], command: CypressCommand): void {
+function interact(interactions: Interaction<Element>[], command: CypressCommand): void {
   interactions
     .reduce((cy: Cypress.Chainable<void>, interaction) =>
       cy
@@ -39,21 +39,21 @@ function interact(interactions: Interaction<void>[], command: CypressCommand): v
     ).then(() => (cypressCommand = null))
 };
 
-function isInteractions(interactions: unknown[]): interactions is ReadonlyInteraction<void>[] {
+function isInteractions(interactions: unknown[]): interactions is AssertionInteraction<Element>[] {
   return interactions.every(isInteraction)
 }
 
 if (typeof Cypress !== 'undefined' ) {
-  Cypress.Commands.add('do', (interaction: Interaction<void> | Interaction<void>[]) =>
-    interact(([] as Interaction<void>[]).concat(interaction), 'do')
+  Cypress.Commands.add('do', (interaction: Interaction<Element> | Interaction<Element>[]) =>
+    interact(([] as Interaction<Element>[]).concat(interaction), 'do')
   );
 
   // NOTE: Save the original `expect` assertion method
   let chaiExpect = cy.expect as (value: unknown) => unknown
 
   // NOTE: Add interaction assertion function, Cypress also overrides `expect` method to a wrapper function
-  Cypress.Commands.add('expect', (interaction: ReadonlyInteraction<void> | ReadonlyInteraction<void>[]) =>
-    interact(([] as ReadonlyInteraction<void>[]).concat(interaction), 'expect')
+  Cypress.Commands.add('expect', (interaction: AssertionInteraction<Element> | AssertionInteraction<Element>[]) =>
+    interact(([] as AssertionInteraction<Element>[]).concat(interaction), 'expect')
   )
 
   // NOTE: Save the new `expect` method in which is wrapped our assertion function
@@ -62,7 +62,7 @@ if (typeof Cypress !== 'undefined' ) {
   // NOTE: Override Cypress's wrapper to our combined `expect`
   // @ts-expect-error TypeScript complains that signature doesn't match with declared one
   cy.expect = (
-    interaction: ReadonlyInteraction<void> | ReadonlyInteraction<void>[] | unknown
+    interaction: AssertionInteraction<Element> | AssertionInteraction<Element>[] | unknown
   ) => {
     let interactions = Array.isArray(interaction) ? interaction : [interaction]
     if (isInteractions(interactions)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1336,9 +1336,9 @@
     istanbul-lib-coverage "^3.0.0"
 
 "@bigtest/bundler@^0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@bigtest/bundler/-/bundler-0.16.0.tgz#29e2eff8c37f0803149eafc8e4597bd775993166"
-  integrity sha512-JCxYWCeJBpBYVRdWnAZHGh11WDq2yUnC6Nb6DbQogcoTqT0qJ0bX5p89MdYQ3YD4N42ZuG6vWH61tghgGjHQxA==
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@bigtest/bundler/-/bundler-0.16.1.tgz#354215c433474cad767b71418afabc246fa75c2d"
+  integrity sha512-Cw7rJe9b74prMcSwfMOHQdU53YLzHzdo5UFYIGx210bOly3NCDZBAt/O0xcpHVTo76fTdSenLw/kEtRTi0WNXg==
   dependencies:
     "@babel/core" "^7.12.9"
     "@babel/plugin-transform-runtime" "^7.12.1"
@@ -1348,6 +1348,7 @@
     "@bigtest/project" "0.18.0"
     "@rollup/plugin-babel" "^5.2.1"
     "@rollup/plugin-commonjs" "^16.0.0"
+    "@rollup/plugin-json" "^4.1.0"
     "@rollup/plugin-node-resolve" "^10.0.0"
     effection "^2.0.1"
     express "^4.17.1"
@@ -1806,6 +1807,13 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@effection/core/-/core-2.0.1.tgz#f200e4df020666ec5dc232da3057bafb63aa19af"
   integrity sha512-Bl2pfu9gbTwlieTgcEhFOwz70QDPXpyVRuOiOqccGVBvZpa3/mzepH6LFZSCyothnc7YO0b31xXV551POiLEow==
+
+"@effection/core@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@effection/core/-/core-2.2.0.tgz#4d11d7948144aecd70a26daf8abaa29ee89bc259"
+  integrity sha512-1RBMrDS0Ya02NEM0TQQRwzlGDSZmwoHhuD3qmWp9NLjZowhO1gJBZ16fQL2NbKvcpS71xho+oZsDedId+C1q8Q==
+  dependencies:
+    abort-controller "^3.0.0"
 
 "@effection/duplex-channel@^2.0.1":
   version "2.0.1"
@@ -3141,6 +3149,13 @@
     magic-string "^0.25.7"
     resolve "^1.17.0"
 
+"@rollup/plugin-json@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-json/-/plugin-json-4.1.0.tgz#54e09867ae6963c593844d8bd7a9c718294496f3"
+  integrity sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==
+  dependencies:
+    "@rollup/pluginutils" "^3.0.8"
+
 "@rollup/plugin-node-resolve@^10.0.0":
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-10.0.0.tgz#44064a2b98df7530e66acf8941ff262fc9b4ead8"
@@ -3153,7 +3168,7 @@
     is-module "^1.0.0"
     resolve "^1.17.0"
 
-"@rollup/pluginutils@^3.1.0":
+"@rollup/pluginutils@^3.0.8", "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
   integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
@@ -4060,9 +4075,9 @@
     defer-to-connect "^2.0.0"
 
 "@testim/chrome-version@^1.0.7":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.0.7.tgz#0cd915785ec4190f08a3a6acc9b61fc38fb5f1a9"
-  integrity sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw==
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.1.2.tgz#092005c5b77bd3bb6576a4677110a11485e11864"
+  integrity sha512-1c4ZOETSRpI0iBfIFUqU4KqwBAB2lHUAlBjZz/YqOHqwM9dTTzjV6Km0ZkiEiSCx/tLr1BtESIKyWWMww+RUqw==
 
 "@testing-library/dom@^8.0.0", "@testing-library/dom@^8.5.0":
   version "8.5.0"
@@ -6631,10 +6646,10 @@ chrome-trace-event@^1.0.2:
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
   integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
 
-chromedriver@95.0.0, chromedriver@^95.0.0:
-  version "95.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-95.0.0.tgz#ecf854cac6df5137a651dcc132edf55612d3db7f"
-  integrity sha512-HwSg7S0ZZYsHTjULwxFHrrUqEpz1+ljDudJM3eOquvqD5QKnR5pSe/GlBTY9UU2tVFRYz8bEHYC4Y8qxciQiLQ==
+chromedriver@96.0.0, chromedriver@^95.0.0:
+  version "96.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-96.0.0.tgz#c8473498e4c94950fa168187b112019cce9e5c6c"
+  integrity sha512-4g6Hn5RHGsbaBmOrJbDlz/hdVPOc22eRsbvoAAMqkZxR2NJCcddHzCw2FAQeW8lX/C7xWVz3nyDsKX3fE9lIIw==
   dependencies:
     "@testim/chrome-version" "^1.0.7"
     axios "^0.21.2"
@@ -9426,10 +9441,15 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.0.0, follow-redirects@^1.10.0, follow-redirects@^1.14.0:
+follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   version "1.14.4"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.4.tgz#838fdf48a8bbdd79e52ee51fb1c94e3ed98b9379"
   integrity sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==
+
+follow-redirects@^1.14.0:
+  version "1.14.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
+  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This reimplements converge and interactions using effection. The major advantage to this is that actions can be cancelled at any point in time.

This also makes a number of changes to the globals API, which are very, very much backward incompatible. This probably needs to be bridged somehow.

It also cleans up the naming and types of things to make things nice and consistent, however this also constitutes breaking changes.

Additionally, the way that interactions are implemented now, prepares three things:

1. **Action delegation:** this requires us to be able to change the reference to the interactor on an action, so the interaction needs to be able to be run with a different interactor. We can do this here by creating a new interaction with the same `run`, but a different `interactor`.
2. **Running interactions as operations from Effection:** this will currently require doing something like `yield Button('Foo').click().operation`, which is very inconvenient. We'd need to add some way for arbitrary objects to mark themselves as operations, maybe by adding a `ToOperation` symbol to Effection, and then adding a property like this to the Interaction.
3. **Implementing actions using Effection:** this will be necessary to properly cancel composite actions. Once (2) is completed, we should be able to elegantly write composed actions using effection operations.