### PR TITLE
Fix missing `@interactors/globals` dep

### DIFF
--- a/.changeset/dry-baboons-learn.md
+++ b/.changeset/dry-baboons-learn.md
@@ -1,0 +1,5 @@
+---
+"@interactors/keyboard": patch
+---
+
+Add missing @interactors/globals dependency

--- a/packages/keyboard/package.json
+++ b/packages/keyboard/package.json
@@ -33,7 +33,8 @@
     "prepack:commonjs": "tsc --project ./tsconfig.build.json --outdir dist/cjs --module commonjs"
   },
   "dependencies": {
-    "@interactors/core": "^1.0.0-rc1.0"
+    "@interactors/core": "^1.0.0-rc1.0",
+    "@interactors/globals": "^1.0.0-rc1.0"
   },
   "devDependencies": {
     "@frontside/tsconfig": "^1.2.0",


### PR DESCRIPTION
## Motivation

`@interactors/keyboard` uses functions from globals package but doesn't have it in dependencies

## Approach

Add missing dependency