### PR TITLE
Pin versions for internal @interactors/* dependencies

### DIFF
--- a/.changeset/wet-news-learn.md
+++ b/.changeset/wet-news-learn.md
@@ -1,0 +1,10 @@
+---
+"@interactors/core": patch
+"@interactors/html": patch
+"@interactors/keyboard": patch
+"@interactors/material-ui": patch
+"@interactors/with-cypress": patch
+"@interactors/globals": patch
+---
+
+Pin versions for internal @interactors/\* dependencies

--- a/.changeset/wet-news-learn.md
+++ b/.changeset/wet-news-learn.md
@@ -8,3 +8,4 @@
 ---
 
 Pin versions for internal @interactors/\* dependencies
+Remove `@interactors/html` re-export from `with-cypress` package

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
     "prepack:commonjs": "tsc --project ./tsconfig.build.json --outdir dist/cjs --module commonjs"
   },
   "dependencies": {
-    "@interactors/globals": "^1.0.0-rc1.0",
+    "@interactors/globals": "1.0.0-rc1.0",
     "@testing-library/dom": "^8.5.0",
     "@testing-library/user-event": "^13.2.1",
     "change-case": "^4.1.1",

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -33,8 +33,8 @@
     "prepack:commonjs": "tsc --project ./tsconfig.build.json --outdir dist/cjs --module commonjs"
   },
   "dependencies": {
-    "@interactors/core": "^1.0.0-rc1.0",
-    "@interactors/keyboard": "^1.0.0-rc1.0"
+    "@interactors/core": "1.0.0-rc1.0",
+    "@interactors/keyboard": "1.0.0-rc1.0"
   },
   "devDependencies": {
     "@frontside/tsconfig": "^1.2.0",

--- a/packages/keyboard/package.json
+++ b/packages/keyboard/package.json
@@ -33,8 +33,8 @@
     "prepack:commonjs": "tsc --project ./tsconfig.build.json --outdir dist/cjs --module commonjs"
   },
   "dependencies": {
-    "@interactors/core": "^1.0.0-rc1.0",
-    "@interactors/globals": "^1.0.0-rc1.0"
+    "@interactors/core": "1.0.0-rc1.0",
+    "@interactors/globals": "1.0.0-rc1.0"
   },
   "devDependencies": {
     "@frontside/tsconfig": "^1.2.0",

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -64,7 +64,7 @@
     "webpack": "^5.53.0"
   },
   "dependencies": {
-    "@interactors/core": "^1.0.0-rc1.0",
-    "@interactors/html": "^1.0.0-rc1.0"
+    "@interactors/core": "1.0.0-rc1.0",
+    "@interactors/html": "1.0.0-rc1.0"
   }
 }

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -64,7 +64,6 @@
     "webpack": "^5.53.0"
   },
   "dependencies": {
-    "@interactors/core": "1.0.0-rc1.0",
     "@interactors/html": "1.0.0-rc1.0"
   }
 }

--- a/packages/material-ui/src/bottom-navigation.ts
+++ b/packages/material-ui/src/bottom-navigation.ts
@@ -1,4 +1,4 @@
-import { click, createInteractor } from "@interactors/core";
+import { click, createInteractor } from "@interactors/html";
 import { isHTMLElement } from "./helpers";
 
 const BottomNavigationAction = createInteractor<HTMLButtonElement>("MUI BottomNavigationAction")

--- a/packages/material-ui/src/calendar.ts
+++ b/packages/material-ui/src/calendar.ts
@@ -1,5 +1,4 @@
-import { createInteractor, including, Interaction, Interactor, not } from "@interactors/core";
-import { click, HTML } from "@interactors/html";
+import { click, HTML, createInteractor, including, Interaction, Interactor, not } from "@interactors/html";
 import { applyGetter, delay, isHTMLElement } from "./helpers";
 import { DatePickerUtils } from "./types";
 

--- a/packages/material-ui/src/helpers.ts
+++ b/packages/material-ui/src/helpers.ts
@@ -1,4 +1,4 @@
-import { Interactor } from "@interactors/core";
+import { Interactor } from "@interactors/html";
 
 type HTMLTypes<T> = T extends `HTML${infer C}Element` ? C : never;
 

--- a/packages/material-ui/src/menu.ts
+++ b/packages/material-ui/src/menu.ts
@@ -1,5 +1,4 @@
-import { createInteractor } from "@interactors/core";
-import { click, HTML } from "@interactors/html";
+import { click, HTML, createInteractor } from "@interactors/html";
 import { Button } from "./button";
 import { applyGetter, isDisabled } from "./helpers";
 

--- a/packages/material-ui/src/radio.ts
+++ b/packages/material-ui/src/radio.ts
@@ -1,5 +1,4 @@
-import { isVisible } from "@interactors/core";
-import { RadioButton } from "@interactors/html";
+import { RadioButton, isVisible } from "@interactors/html";
 import { isHTMLElement } from "./helpers";
 
 const RadioInteractor = RadioButton.extend("radio")

--- a/packages/material-ui/src/select.ts
+++ b/packages/material-ui/src/select.ts
@@ -1,5 +1,4 @@
-import { createInteractor, Interactor } from "@interactors/core";
-import { click, HTML } from "@interactors/html";
+import { click, HTML, createInteractor, Interactor } from "@interactors/html";
 import { createFormFieldFilters } from "./form-field-filters";
 import { isDefined, isHTMLElement, delay, dispatchMouseDown, getInputLabel, applyGetter, isDisabled } from "./helpers";
 

--- a/packages/material-ui/src/types.ts
+++ b/packages/material-ui/src/types.ts
@@ -1,4 +1,4 @@
-import { InteractorConstructor } from "@interactors/core";
+import { InteractorConstructor } from "@interactors/html";
 
 /**
  * Helper functions from `@date-io/*` utils

--- a/packages/material-ui/test/icon-button.test.tsx
+++ b/packages/material-ui/test/icon-button.test.tsx
@@ -1,5 +1,5 @@
 import { test, visit } from "bigtest";
-import { createInteractor, including } from "@interactors/core";
+import { createInteractor, including } from "@interactors/html";
 import { Button } from "../src";
 import { IconButton as Component } from "@material-ui/core";
 import { PhotoCamera } from '@material-ui/icons';

--- a/packages/with-cypress/cypress.json
+++ b/packages/with-cypress/cypress.json
@@ -8,6 +8,6 @@
   "pluginsFile": "cypress/plugins/index.js",
   "screenshotsFolder": "cypress/screenshots",
   "videosFolder": "cypress/videos",
-  "supportFile": "cypress/support/index.js",
+  "supportFile": "cypress/support/index.ts",
   "configFile": "cypress/tsconfig.json"
 }

--- a/packages/with-cypress/cypress/integration/interactor.spec.ts
+++ b/packages/with-cypress/cypress/integration/interactor.spec.ts
@@ -1,4 +1,4 @@
-import { Button, including, matching } from '../../src';
+import { Button, including, matching } from '@interactors/html';
 
 describe('Cypress with Interactors', () => {
   beforeEach(() => {

--- a/packages/with-cypress/cypress/support/index.ts
+++ b/packages/with-cypress/cypress/support/index.ts
@@ -1,0 +1,1 @@
+import '../../dist'

--- a/packages/with-cypress/cypress/tsconfig.json
+++ b/packages/with-cypress/cypress/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "types": ["cypress"],
     "sourceMap": false
-  }
+  },
+  "include": ["./**/*.ts"]
 }

--- a/packages/with-cypress/package.json
+++ b/packages/with-cypress/package.json
@@ -15,8 +15,8 @@
     "README.md"
   ],
   "dependencies": {
-    "@interactors/core": "^1.0.0-rc1.0",
-    "@interactors/html": "^1.0.0-rc1.0"
+    "@interactors/core": "1.0.0-rc1.0",
+    "@interactors/html": "1.0.0-rc1.0"
   },
   "peerDependencies": {
     "cypress": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/packages/with-cypress/package.json
+++ b/packages/with-cypress/package.json
@@ -15,8 +15,8 @@
     "README.md"
   ],
   "dependencies": {
-    "@interactors/core": "1.0.0-rc1.0",
-    "@interactors/html": "1.0.0-rc1.0"
+    "@interactors/core": "^1.0.0-rc1.0",
+    "@interactors/globals": "^1.0.0-rc1.0"
   },
   "peerDependencies": {
     "cypress": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -32,6 +32,7 @@
     "@frontside/eslint-config": "^2.1.0",
     "@frontside/tsconfig": "^1.2.0",
     "@frontside/typescript": "^1.1.1",
+    "@interactors/html": "^1.0.0-rc1.0",
     "cypress": "^8.0.0",
     "start-server-and-test": "^1.11.7",
     "ts-node": "^10.4.0"

--- a/packages/with-cypress/src/index.ts
+++ b/packages/with-cypress/src/index.ts
@@ -1,2 +1,1 @@
-export * from '@interactors/html';
 import './cypress';


### PR DESCRIPTION
## Motivation

We need to reduce problems with back compatibility between versions.

## Approach

Remove `^` sign to pin version of internal interactors packages
