### PR TITLE
Fix pressing functional keys and add missed chars

### DIFF
--- a/.changeset/dry-ducks-remain.md
+++ b/.changeset/dry-ducks-remain.md
@@ -1,0 +1,6 @@
+---
+"@interactors/globals": patch
+"@interactors/keyboard": patch
+---
+
+Improve keyboard layout, by adding missing chars and fix pressing functional keys

--- a/packages/globals/src/index.ts
+++ b/packages/globals/src/index.ts
@@ -1,2 +1,2 @@
 export * from './globals'
-export { KeyboardLayout, KeyCode } from './keyboard-layout'
+export * from './keyboard-layout'

--- a/packages/globals/src/keyboard-layout.ts
+++ b/packages/globals/src/keyboard-layout.ts
@@ -99,11 +99,60 @@ export type KeyCode =
   | "Slash"
   | "Backquote"
   | "BracketLeft"
-  | "Backslack"
+  | "Backslash"
   | "BracketRight"
   | "Quote";
 
+export const FunctionalKeys: KeyCode[] = [
+  "Backspace",
+  "Tab",
+  "Enter",
+  "ShiftLeft",
+  "ShiftRight",
+  "ControlLeft",
+  "ControlRight",
+  "AltLeft",
+  "AltRight",
+  "Pause",
+  "CapsLock",
+  "Escape",
+  "PageUp",
+  "PageDown",
+  "End",
+  "Home",
+  "ArrowLeft",
+  "ArrowUp",
+  "ArrowRight",
+  "ArrowDown",
+  "PrintScreen",
+  "Insert",
+  "Delete",
+  "MetaLeft",
+  "MetaRight",
+  "ContextMenu",
+  "F1",
+  "F2",
+  "F3",
+  "F4",
+  "F5",
+  "F6",
+  "F7",
+  "F8",
+  "F9",
+  "F10",
+  "F11",
+  "F12",
+  "NumLock",
+  "ScrollLock",
+];
+
+export interface Key {
+  code: KeyCode;
+  key: string;
+  shiftKey?: true;
+}
+
 export interface KeyboardLayout {
-  getKey(code: KeyCode): string | undefined;
-  getCode(key: string): KeyCode | undefined;
+  getByCode(code: KeyCode): Key | undefined;
+  getByKey(key: string): Key | undefined;
 }

--- a/packages/keyboard/src/keyboard.ts
+++ b/packages/keyboard/src/keyboard.ts
@@ -1,4 +1,4 @@
-import { globals, KeyCode } from '@interactors/globals';
+import { FunctionalKeys, globals, KeyCode } from '@interactors/globals';
 import { createInteractor } from '@interactors/core';
 import { dispatchInput, dispatchKeyDown, dispatchKeyUp } from './dispatch';
 
@@ -19,12 +19,13 @@ const KeyboardInteractor = createInteractor('Keyboard')
       await interactor.perform((element) => {
         let activeElement = (element.ownerDocument.activeElement || element.ownerDocument.body) as HTMLElement;
         if(options.key && !options.code) {
-          options.code = globals.keyboardLayout.getCode(options.key);
+          options = { ...options, ...globals.keyboardLayout.getByKey(options.key) };
         }
         if(options.code && !options.key) {
-          options.key = globals.keyboardLayout.getKey(options.code);
+          options = { ...options, ...globals.keyboardLayout.getByCode(options.code) };
         }
-        if(dispatchKeyDown(activeElement, options) && isTextElement(activeElement)) {
+        let isFunctionalKey = options.code ? FunctionalKeys.includes(options.code) : false;
+        if(dispatchKeyDown(activeElement, options) && isTextElement(activeElement) && !isFunctionalKey) {
           // don't change the value if the keydown event was stopped
           setValue(activeElement, activeElement.value + options.key);
           // input is not dispatched if the keydown event was stopped

--- a/packages/keyboard/src/layout.ts
+++ b/packages/keyboard/src/layout.ts
@@ -1,122 +1,96 @@
-import { KeyCode, KeyboardLayout } from '@interactors/globals';
+import { Key, KeyCode, KeyboardLayout } from "@interactors/globals";
 
-export function createKeyboardLayout(map: Iterable<[KeyCode, string]>): KeyboardLayout {
-  let keyMap = new Map(map);
-  let codeMap = new Map(Array.from(map).map(([key, value]) => [value, key]));
+export const defaultKeyMap = [
+  ..."0123456789".split("").map((digit) => ({ code: `Digit${digit}`, key: digit })),
+  ...")!@#$%^&*(".split("").map((key, digit) => ({ code: `Digit${digit}`, key, shiftKey: true })),
+  ..."abcdefghijklmnopqrstuvwxyz".split("").map((key) => ({ code: `Key${key.toUpperCase()}`, key })),
+  ..."ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("").map((key) => ({ code: `Key${key}`, key, shiftKey: true })),
+  ...Array.from({ length: 12 })
+    .map((_, digit) => `F${digit + 1}`)
+    .map((key) => ({ code: key, key })),
+  ...[
+    "Backspace",
+    "Tab",
+    "Enter",
+    "Pause",
+    "CapsLock",
+    "Escape",
+    "PageUp",
+    "PageDown",
+    "End",
+    "Home",
+    "ArrowLeft",
+    "ArrowUp",
+    "ArrowRight",
+    "ArrowDown",
+    "PrintScreen",
+    "Insert",
+    "Delete",
+    "ContextMenu",
+    "NumLock",
+    "ScrollLock",
+  ].map((code) => ({ code, key: code })),
+
+  { code: "Space", key: " " },
+  { code: "AltLeft", key: "Alt" },
+  { code: "AltRight", key: "Alt" },
+  { code: "ShiftLeft", key: "Shift" },
+  { code: "ShiftRight", key: "Shift" },
+  { code: "ControlLeft", key: "Control" },
+  { code: "ControlRight", key: "Control" },
+  { code: "MetaLeft", key: "Meta" },
+  { code: "MetaRight", key: "Meta" },
+
+  { code: "Semicolon", key: ";" },
+  { code: "Equal", key: "=" },
+  { code: "Comma", key: "," },
+  { code: "Minus", key: "-" },
+  { code: "Period", key: "." },
+  { code: "Slash", key: "/" },
+  { code: "Backquote", key: "`" },
+  { code: "BracketLeft", key: "[" },
+  { code: "Backslash", key: "\\" },
+  { code: "BracketRight", key: "]" },
+  { code: "Quote", key: "'" },
+
+  { code: "Semicolon", key: ":", shiftKey: true },
+  { code: "Equal", key: "+", shiftKey: true },
+  { code: "Comma", key: "<", shiftKey: true },
+  { code: "Minus", key: "_", shiftKey: true },
+  { code: "Period", key: ">", shiftKey: true },
+  { code: "Slash", key: "?", shiftKey: true },
+  { code: "Backquote", key: "~", shiftKey: true },
+  { code: "BracketLeft", key: "{", shiftKey: true },
+  { code: "Backslash", key: "|", shiftKey: true },
+  { code: "BracketRight", key: "}", shiftKey: true },
+  { code: "Quote", key: '"', shiftKey: true },
+
+  ..."0123456789".split("").map((digit) => ({ code: `Numpad${digit}`, key: digit })),
+  { code: "NumpadMultiply", key: "*" },
+  { code: "NumpadAdd", key: "+" },
+  { code: "NumpadSubtract", key: "-" },
+  { code: "NumpadDecimal", key: "." },
+  { code: "NumpadDivide", key: "/" },
+] as Key[];
+
+export function createKeyboardLayout(override: Key[] = []): KeyboardLayout {
+  let codeMap = new Map<KeyCode, Key[]>();
+  let keyMap = new Map<string, Key[]>();
+
+  [...override, ...defaultKeyMap].forEach((key) => {
+    codeMap.get(key.code)?.push(key) ?? codeMap.set(key.code, [key]);
+    keyMap.get(key.key)?.push(key) ?? keyMap.set(key.key, [key]);
+  });
 
   return {
-    getKey(code: KeyCode): string | undefined {
-      return keyMap.get(code);
+    getByCode(code: KeyCode): Key | undefined {
+      return codeMap.get(code)?.[0];
     },
 
-    getCode(key: string): KeyCode | undefined {
-      return codeMap.get(key);
+    getByKey(key: string): Key | undefined {
+      return keyMap.get(key)?.[0];
     },
-  }
+  };
 }
 
-export const US_INTERNATIONAL = createKeyboardLayout([
-  ["Backspace", "Backspace"],
-  ["Tab", "Tab"],
-  ["Enter", "Enter"],
-  ["ShiftLeft", "Shift"],
-  ["ShiftRight", "Shift"],
-  ["ControlLeft", "Control"],
-  ["ControlRight", "Control"],
-  ["AltLeft", "Alt"],
-  ["AltRight", "Alt"],
-  ["Pause", "Pause"],
-  ["CapsLock", "CapsLock"],
-  ["Escape", "Escape"],
-  ["Space", " "],
-  ["PageUp", "PageUp"],
-  ["PageDown", "PageDown"],
-  ["End", "End"],
-  ["Home", "Home"],
-  ["ArrowLeft", "ArrowLeft"],
-  ["ArrowUp", "ArrowUp"],
-  ["ArrowRight", "ArrowRight"],
-  ["ArrowDown", "ArrowDown"],
-  ["PrintScreen", "PrintScreen"],
-  ["Insert", "Insert"],
-  ["Delete", "Delete"],
-  ["Digit0", "0"],
-  ["Digit1", "1"],
-  ["Digit2", "2"],
-  ["Digit3", "3"],
-  ["Digit4", "4"],
-  ["Digit5", "5"],
-  ["Digit6", "6"],
-  ["Digit7", "7"],
-  ["Digit8", "8"],
-  ["Digit9", "9"],
-  ["KeyA", "a"],
-  ["KeyB", "b"],
-  ["KeyC", "c"],
-  ["KeyD", "d"],
-  ["KeyE", "e"],
-  ["KeyF", "f"],
-  ["KeyG", "g"],
-  ["KeyH", "h"],
-  ["KeyI", "i"],
-  ["KeyJ", "j"],
-  ["KeyK", "k"],
-  ["KeyL", "l"],
-  ["KeyM", "m"],
-  ["KeyN", "n"],
-  ["KeyO", "o"],
-  ["KeyP", "p"],
-  ["KeyQ", "q"],
-  ["KeyR", "r"],
-  ["KeyS", "s"],
-  ["KeyT", "t"],
-  ["KeyU", "u"],
-  ["KeyV", "v"],
-  ["KeyW", "w"],
-  ["KeyX", "x"],
-  ["KeyY", "y"],
-  ["KeyZ", "z"],
-  ["MetaLeft", "Meta"],
-  ["MetaRight", "Meta"],
-  ["ContextMenu", "ContextMenu"],
-  ["Numpad0", "0"],
-  ["Numpad1", "1"],
-  ["Numpad2", "2"],
-  ["Numpad3", "3"],
-  ["Numpad4", "4"],
-  ["Numpad5", "5"],
-  ["Numpad6", "6"],
-  ["Numpad7", "7"],
-  ["Numpad8", "8"],
-  ["Numpad9", "9"],
-  ["NumpadMultiply", "*"],
-  ["NumpadAdd", "+"],
-  ["NumpadSubtract", "-"],
-  ["NumpadDecimal", "."],
-  ["NumpadDivide", "/"],
-  ["F1", "F1"],
-  ["F2", "F2"],
-  ["F3", "F3"],
-  ["F4", "F4"],
-  ["F5", "F5"],
-  ["F6", "F6"],
-  ["F7", "F7"],
-  ["F8", "F8"],
-  ["F9", "F9"],
-  ["F10", "F10"],
-  ["F11", "F11"],
-  ["F12", "F12"],
-  ["NumLock", "NumLock"],
-  ["ScrollLock", "ScrollLock"],
-  ["Semicolon", ";"],
-  ["Equal", "="],
-  ["Comma", ","],
-  ["Minus", "-"],
-  ["Period", "."],
-  ["Slash", "/"],
-  ["Backquote", "`"],
-  ["BracketLeft", "["],
-  ["Backslack", "\\"],
-  ["BracketRight", "]"],
-  ["Quote", "'"],
-]);
+export const US_INTERNATIONAL = createKeyboardLayout();

--- a/packages/keyboard/test/keyboard.test.ts
+++ b/packages/keyboard/test/keyboard.test.ts
@@ -5,7 +5,7 @@ import { Keyboard, createKeyboardLayout } from '../src';
 import { dom } from './helpers';
 
 const TextField = createInteractor<HTMLInputElement | HTMLTextAreaElement>('text field')
-  .selector('input')
+  .selector('input,textarea')
   .filters({
     id: (e) => e.id,
   })
@@ -22,6 +22,26 @@ const Heading = createInteractor('heading')
 
 describe('Keyboard', () => {
   describe('press', () => {
+    let domFixture = `
+      <p>
+        <textarea type="text" id="nameField">hello</textarea>
+        <h1 id="keydown"></h1>
+        <h1 id="keyup"></h1>
+        <h1 id="input"></h1>
+      </p>
+      <script>
+        nameField.addEventListener('keydown', (event) => {
+          keydown.textContent = ['success', event.target.value, event.key, event.code].join(' ');
+        });
+        nameField.addEventListener('keyup', (event) => {
+          keyup.textContent = ['success', event.target.value, event.key, event.code].join(' ');
+        });
+        nameField.addEventListener('input', (event) => {
+          input.textContent = ['success', event.target.value, event.inputType, event.data].join(' ');
+        });
+      </script>
+    `;
+
     it('dispatches events with the given key to the body when no element active', async () => {
       dom(`
         <p>
@@ -39,34 +59,14 @@ describe('Keyboard', () => {
         </script>
       `);
 
-      globals.document.getElementById('nameField');
       await Keyboard.press({ key: 'w' });
       await Heading({ id: 'keydown' }).has({ text: 'success w KeyW' });
       await Heading({ id: 'keyup' }).has({ text: 'success w KeyW' });
     });
 
     it('dispatches events with the given key to the active element', async () => {
-      dom(`
-        <p>
-          <input value="hello" type="text" id="nameField"/>
-          <h1 id="keydown"></h1>
-          <h1 id="keyup"></h1>
-          <h1 id="input"></h1>
-        </p>
-        <script>
-          nameField.addEventListener('keydown', (event) => {
-            keydown.textContent = ['success', event.target.value, event.key, event.code].join(' ');
-          });
-          nameField.addEventListener('keyup', (event) => {
-            keyup.textContent = ['success', event.target.value, event.key, event.code].join(' ');
-          });
-          nameField.addEventListener('input', (event) => {
-            input.textContent = ['success', event.target.value, event.inputType, event.data].join(' ');
-          });
-        </script>
-      `);
+      dom(domFixture);
 
-      globals.document.getElementById('nameField');
       await TextField({ id: 'nameField' }).focus();
       await Keyboard.press({ key: 'w' });
       await Heading({ id: 'keydown' }).has({ text: 'success hello w KeyW' });
@@ -75,32 +75,34 @@ describe('Keyboard', () => {
     });
 
     it('dispatches events with the given code to the active element', async () => {
-      dom(`
-        <p>
-          <input value="hello" type="text" id="nameField"/>
-          <h1 id="keydown"></h1>
-          <h1 id="keyup"></h1>
-          <h1 id="input"></h1>
-        </p>
-        <script>
-          nameField.addEventListener('keydown', (event) => {
-            keydown.textContent = ['success', event.target.value, event.key, event.code].join(' ');
-          });
-          nameField.addEventListener('keyup', (event) => {
-            keyup.textContent = ['success', event.target.value, event.key, event.code].join(' ');
-          });
-          nameField.addEventListener('input', (event) => {
-            input.textContent = ['success', event.target.value, event.inputType, event.data].join(' ');
-          });
-        </script>
-      `);
+      dom(domFixture);
 
-      globals.document.getElementById('nameField');
+
+      await TextField({ id: "nameField" }).focus();
+      await Keyboard.press({ code: "KeyW" });
+      await Heading({ id: "keydown" }).has({ text: "success hello w KeyW" });
+      await Heading({ id: "keyup" }).has({ text: "success hellow w KeyW" });
+      await Heading({ id: "input" }).has({ text: "success hellow insertText w" });
+    });
+
+    it("dispatches events with the `Enter` code to the active element", async () => {
+      dom(domFixture);
+
       await TextField({ id: 'nameField' }).focus();
-      await Keyboard.press({ code: 'KeyW' });
-      await Heading({ id: 'keydown' }).has({ text: 'success hello w KeyW' });
-      await Heading({ id: 'keyup' }).has({ text: 'success hellow w KeyW' });
-      await Heading({ id: 'input' }).has({ text: 'success hellow insertText w' });
+      await Keyboard.press({ code: 'Home' });
+      await Keyboard.press({ code: 'Enter' });
+      await Heading({ id: 'keydown' }).has({ text: 'success hello Enter Enter' });
+      await Heading({ id: 'keyup' }).has({ text: 'success hello Enter Enter' });
+    });
+
+    it("dispatches events with the uppercased `w` to the active element", async () => {
+      dom(domFixture);
+
+      await TextField({ id: 'nameField' }).focus();
+      await Keyboard.press({ key: 'W' });
+      await Heading({ id: "keydown" }).has({ text: "success hello W KeyW" });
+      await Heading({ id: "keyup" }).has({ text: "success helloW W KeyW" });
+      await Heading({ id: "input" }).has({ text: "success helloW insertText W" });
     });
   });
 
@@ -127,8 +129,8 @@ describe('Keyboard', () => {
   describe('layout', () => {
     it('can change keyboard layout', async () => {
       setKeyboardLayout(createKeyboardLayout([
-        ['KeyW', 'q'],
-        ['KeyX', 'b'],
+        { code: 'KeyW', key: 'q' },
+        { code: 'KeyX', key: 'b' },
       ]));
 
       dom(`


### PR DESCRIPTION
## Motivation

There was problem with pressing functional keys, when instead of just sending `keyDown` and `keyUp` events the Keyboard interactor appends key code as a value to a text field

## Approach

Reworked keyboard layout inspired by [user-event](https://github.com/testing-library/user-event/blob/e9635f656298ef1f96bd255b0d89031e04441537/src/keyboard/keyMap.ts) library and added some missing chars
Added list of functional keys to filter input event
