### PR TITLE
Update material-ui interactors to use getters

### DIFF
--- a/.changeset/empty-pans-laugh.md
+++ b/.changeset/empty-pans-laugh.md
@@ -1,0 +1,5 @@
+---
+"@interactors/material-ui": patch
+---
+
+Update material-ui interactors to use getters

--- a/packages/material-ui/src/accordion.ts
+++ b/packages/material-ui/src/accordion.ts
@@ -1,5 +1,5 @@
 import { HTML, innerText } from "@interactors/html";
-import { applyGetter, isDisabled, isHTMLElement } from "./helpers";
+import { isDisabled, isHTMLElement } from "./helpers";
 
 const getSummary = (element: HTMLElement) => element.querySelector('[class*="MuiAccordionSummary-root"]');
 const isExpanded = (element: HTMLElement) => getSummary(element)?.getAttribute("aria-expanded") == "true";
@@ -30,12 +30,12 @@ const AccordionInteractor = HTML.extend<HTMLElement>("MUIAccordion")
   })
   .actions({
     expand: async (interactor) => {
-      if (await applyGetter(interactor, isExpanded)) return;
+      if (await interactor.expanded()) return;
 
       await interactor.find(AccordionSummary()).click();
     },
     collapse: async (interactor) => {
-      if (!(await applyGetter(interactor, isExpanded))) return;
+      if (!(await interactor.expanded())) return;
 
       await interactor.find(AccordionSummary()).click();
     },

--- a/packages/material-ui/src/helpers.ts
+++ b/packages/material-ui/src/helpers.ts
@@ -1,5 +1,3 @@
-import { Interactor } from "@interactors/html";
-
 type HTMLTypes<T> = T extends `HTML${infer C}Element` ? C : never;
 
 type HTMLElementTypes = HTMLTypes<keyof typeof window>;
@@ -44,17 +42,6 @@ export function getInputLabel(
       .map((element) => (isHTMLElement(element, "Label") ? element : null))
       .find(isDefined)
   );
-}
-
-export async function applyGetter<E extends Element, I, R>(
-  interactor: Interactor<E, I>,
-  getter: (element: E) => R
-): Promise<R> {
-  let value: unknown;
-
-  await interactor.perform((element) => (value = getter(element)));
-
-  return value as R;
 }
 
 // NOTE: Copy-paste from https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/fill-in.ts

--- a/packages/material-ui/src/menu.ts
+++ b/packages/material-ui/src/menu.ts
@@ -1,6 +1,6 @@
 import { click, HTML, createInteractor } from "@interactors/html";
 import { Button } from "./button";
-import { applyGetter, isDisabled } from "./helpers";
+import { isDisabled } from "./helpers";
 
 const MenuItemInteractor = HTML.extend<HTMLElement>("MUIMenuItem")
   .selector('[class*="MuiMenuItem-root"][role="menuitem"]')
@@ -20,14 +20,13 @@ const MenuListInteractor = createInteractor<HTMLElement>("MUIMenuList")
 
 const MenuInteractor = Button.extend("MUIMenu")
   .selector(`${Button().options.specification.selector as string}[aria-haspopup="true"]`)
+  .filters({ menuId: (element) => element.getAttribute("aria-controls") ?? "" })
   .actions({
     open: async ({ perform }) => perform((element) => click(element)),
     click: async (interactor, value: string) => {
       await interactor.perform((element) => click(element));
 
-      let menuId = await applyGetter(interactor, (element) => element.getAttribute("aria-controls") ?? "");
-
-      await MenuListInteractor(menuId).find(MenuItemInteractor(value)).click();
+      await MenuListInteractor(await interactor.menuId()).find(MenuItemInteractor(value)).click();
     },
   });
 

--- a/packages/material-ui/src/select.ts
+++ b/packages/material-ui/src/select.ts
@@ -1,6 +1,6 @@
 import { click, HTML, createInteractor, Interactor, innerText } from "@interactors/html";
 import { createFormFieldFilters } from "./form-field-filters";
-import { isDefined, isHTMLElement, delay, dispatchMouseDown, getInputLabel, applyGetter, isDisabled } from "./helpers";
+import { isDefined, isHTMLElement, delay, dispatchMouseDown, getInputLabel, isDisabled } from "./helpers";
 
 export const SelectOption = HTML.extend<HTMLLIElement>("MUISelectOption")
   .selector('li[role="option"]')
@@ -93,7 +93,7 @@ const SelectInteractor = BaseSelect.extend("MUISelect")
   .filters({ value: getValueText })
   .actions({
     choose: async (interactor, value: string) => {
-      if ((await applyGetter(interactor, getValueText)) == value) return;
+      if ((await interactor.value()) == value) return;
 
       let labelId = await openSelectOptionsList(interactor);
       await SelectOptionsList(labelId).find(SelectOption(value)).choose();
@@ -104,7 +104,7 @@ const MultiSelectInteractor = BaseSelect.extend("MUIMultiSelect")
   .filters({ values: getChipLabels })
   .actions({
     choose: async (interactor, value: string) => {
-      let selected = await applyGetter(interactor, getChipLabels);
+      let selected = await interactor.values();
 
       if (selected.length == 1 && selected[0] == value) return;
 
@@ -114,7 +114,7 @@ const MultiSelectInteractor = BaseSelect.extend("MUIMultiSelect")
       await closeSelectOptionsList(labelId);
     },
     select: async (interactor, value: string) => {
-      let selected = await applyGetter(interactor, getChipLabels);
+      let selected = await interactor.values();
 
       if (selected.includes(value)) return;
 
@@ -123,7 +123,7 @@ const MultiSelectInteractor = BaseSelect.extend("MUIMultiSelect")
       await closeSelectOptionsList(labelId);
     },
     deselect: async (interactor, value: string) => {
-      let selected = await applyGetter(interactor, getChipLabels);
+      let selected = await interactor.values();
 
       if (!selected.includes(value)) return;
 


### PR DESCRIPTION
## Motivation

Interactors have ability to use filters as getters to read value from specific filter. But In material-ui interactors we don't use it.

## Approach

Update material-ui interactors to use the new API
