### PR TITLE
Remember interactor name and action arguments

### DIFF
--- a/.changeset/quick-actors-speak.md
+++ b/.changeset/quick-actors-speak.md
@@ -1,0 +1,6 @@
+---
+"@interactors/core": minor
+"@interactors/globals": minor
+---
+
+Store interactor name and interaction arguments for reflection

--- a/packages/core/src/constructor.ts
+++ b/packages/core/src/constructor.ts
@@ -61,6 +61,7 @@ export function instantiateInteractor<E extends Element, F extends Filters<E>, A
       return createInteraction('action', {
         name: "perform",
         interactor,
+        args: [],
         description: `run perform on ${formatDescription(options)}`,
         run: (interactor) => converge(() => fn(resolver(interactor.options))),
       });
@@ -70,6 +71,7 @@ export function instantiateInteractor<E extends Element, F extends Filters<E>, A
       return createInteraction('assertion', {
         name: "assert",
         interactor,
+        args: [],
         description: `${formatDescription(options)} asserts`,
         run: (interactor) => converge(() => { fn(resolver(interactor.options)) }),
       });
@@ -84,6 +86,7 @@ export function instantiateInteractor<E extends Element, F extends Filters<E>, A
       return createInteraction('assertion', {
         name: "is",
         interactor,
+        args: [filters],
         filters,
         description: `${formatDescription(options)} matches filters: ${filter.description}`,
         run: (interactor) => converge(() => {
@@ -107,6 +110,7 @@ export function instantiateInteractor<E extends Element, F extends Filters<E>, A
       return createInteraction('assertion', {
         name: 'exists',
         interactor,
+        args: [],
         description: `${formatDescription(options)} exists`,
         run: (interactor) => converge(() => {
           resolveFirst(unsafeSyncResolveParent(interactor.options), options);
@@ -118,6 +122,7 @@ export function instantiateInteractor<E extends Element, F extends Filters<E>, A
       return createInteraction('assertion', {
         name: 'absent',
         interactor,
+        args: [],
         description: `${formatDescription(options)} does not exist`,
         run: (interactor) => converge(() => {
           resolveEmpty(unsafeSyncResolveParent(interactor.options), options);
@@ -161,6 +166,7 @@ export function instantiateInteractor<E extends Element, F extends Filters<E>, A
           return createInteraction('assertion', {
             name: filterName,
             interactor,
+            args: [],
             description: `${filterName} of ${formatDescription(options)}`,
             run: (interactor) => converge(() => applyFilter(filter, resolver(interactor.options))),
           }, (parentElement) => {
@@ -195,6 +201,7 @@ export function createConstructor<E extends Element, FP extends FilterParams<any
   }
 
   return Object.assign(initInteractor, {
+    interactorName: name,
     selector: (value: string): InteractorConstructor<E, FP, FM, AM> => {
       return createConstructor(name, { ...specification, selector: value });
     },

--- a/packages/core/src/interaction.ts
+++ b/packages/core/src/interaction.ts
@@ -72,7 +72,7 @@ export type InteractionOptions<E extends Element, T> = {
   name: string;
   description: string;
   filters?: FilterParams<any, any>;
-  args?: unknown[];
+  args: unknown[];
   interactor: Interactor<E, any>;
   run: (interactor: Interactor<E, any>) => Operation<T>;
 }
@@ -118,6 +118,7 @@ export function createInteraction<E extends Element, T, Q>(type: InteractionType
     description: options.description,
     interactor: options.interactor,
     run: options.run,
+    args: options.args,
     action,
     check: type === 'assertion' ? action : undefined,
     code: () => serializedOptions.code(),

--- a/packages/core/src/serialize.ts
+++ b/packages/core/src/serialize.ts
@@ -37,7 +37,7 @@ export function serializeInteractionOptions<E extends Element, T>(
     ancestors,
     name,
     type,
-    args: filters ? [filters] : args ? args : undefined,
+    args,
     code() {
       let serializedArgs = "";
       if (filters) {

--- a/packages/core/src/specification.ts
+++ b/packages/core/src/specification.ts
@@ -199,6 +199,7 @@ export type FilterParams<E extends Element, F extends Filters<E>> = keyof F exte
  * @typeParam A the actions of this interactor, this is usually inferred from the specification
  */
 export interface InteractorConstructor<E extends Element, FP extends FilterParams<any, any>, FM extends FilterMethods<any, any>, AM extends ActionMethods<any, any, any>> {
+  interactorName: string;
   selector(value: string | SelectorFn<E>): InteractorConstructor<E, FP, FM, AM>;
   locator(value: FilterDefinition<string, E>): InteractorConstructor<E, FP, FM, AM>;
   filters<FR extends Filters<E>>(filters: FR): InteractorConstructor<E, MergeObjects<FP, FilterParams<E, FR>>, MergeObjects<FM, FilterMethods<E, FR>>, AM>;

--- a/packages/globals/src/globals.ts
+++ b/packages/globals/src/globals.ts
@@ -37,7 +37,7 @@ export type InteractionOptions = InteractorOptions & {
   name: string;
   type: InteractionType;
   code: () => string;
-  args?: unknown[];
+  args: unknown[];
   ancestors?: InteractorOptions[];
 };
 

--- a/packages/globals/test/globals.test.ts
+++ b/packages/globals/test/globals.test.ts
@@ -54,6 +54,7 @@ describe("@interactors/globals", () => {
               name: "plain",
               type: "action",
               code: () => "",
+              args: [],
             },
             [Symbol.operation]: Promise.resolve(),
           }
@@ -78,6 +79,7 @@ describe("@interactors/globals", () => {
             name: "foo",
             type: "action",
             code: () => "",
+            args: [],
           },
           [Symbol.operation]: Promise.resolve(),
         },


### PR DESCRIPTION
## Motivation

In order to enable remote interactors (see #178), we need to track more information about the interactions themselves. This adds the arguments to an interaction, as well as the name of the interactor to the public information that can be reflected upon.

## Approach

Expose these as part of the public API