### PR TITLE
Update preview action to v2

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         registry-url: https://registry.npmjs.org
     - name: Publish PR Preview
-      uses: thefrontside/actions/publish-pr-preview@main
+      uses: thefrontside/actions/publish-pr-preview@v2
       with:
         INSTALL_SCRIPT: yarn install && yarn prepack:all
       env:


### PR DESCRIPTION
Fixed a bug to the new preview action in https://github.com/thefrontside/actions/pull/71 and we're also deprecating the `main` branch