### PR TITLE
Add workaround to support Cypress 10

### DIFF
--- a/.changeset/rude-parents-worry.md
+++ b/.changeset/rude-parents-worry.md
@@ -1,0 +1,5 @@
+---
+"@interactors/with-cypress": patch
+---
+
+Add support Cypress 10

--- a/packages/with-cypress/README.md
+++ b/packages/with-cypress/README.md
@@ -7,7 +7,7 @@
 
 [Interactors][] are Page Objects for component libraries and design systems.
 This package lets you use them seamlessly within [Cypress][]. Learn more at
-[https://frontside.com/interactors/docs/integrations#cypress](https://frontside.com/interactors/docs/integrations#cypress)
+[https://frontside.com/interactors/docs/cypress](https://frontside.com/interactors/docs/cypress)
 
 [Interactors]: https://frontside.com/interactors
 [Cypress]: https://cypress.io

--- a/packages/with-cypress/package.json
+++ b/packages/with-cypress/package.json
@@ -19,7 +19,7 @@
     "@interactors/globals": "^1.0.0-rc1.1"
   },
   "peerDependencies": {
-    "cypress": "^6.0.0 || ^7.0.0 || ^8.0.0"
+    "cypress": ">=6.0.0 <11.0.0"
   },
   "scripts": {
     "start": "cd ../../sample/ && npm install && npm run start -- -p 3000",

--- a/packages/with-cypress/src/cypress.ts
+++ b/packages/with-cypress/src/cypress.ts
@@ -54,6 +54,12 @@ if (typeof Cypress !== 'undefined' ) {
   let interactionExpect = (interaction: AssertionInteraction<Element> | AssertionInteraction<Element>[]) => (
     interact(([] as AssertionInteraction<Element>[]).concat(interaction), 'expect')
   )
+  try {
+    // NOTE: Add interaction assertion function, Cypress also overrides `expect` method to a wrapper function
+    // This need for Cypress <10 versions
+    Cypress.Commands.add('expect', interactionExpect);
+  }
+  catch (e) {}
   // @ts-expect-error Cypress stores a reference to commands object and use it to check overwiritability of commands
   // https://github.com/cypress-io/cypress/blob/d378ec423a4a2799f90a6536f82e4504bc8b3c9e/packages/driver/src/cypress/commands.ts#L155
   Cypress.Commands._commands['expect'] = interactionExpect;


### PR DESCRIPTION
## Motivation

Cypress added checks to restrict using `add` method for adding commands to overwrite reserved built-in commands. https://github.com/cypress-io/cypress/pull/18923
According the PR https://github.com/cypress-io/cypress/pull/18587 we should use `overwrite` command instead. But the problem is `expect` isn't in built-in commands object, so checks can't be passed

## Approach

Add a workaround to able to overwrite built-in `expect`

### TODOs and Open Questions

- [ ] Check that the original `expect` works well in folio repo
- [x] Create Cypress issue/PR to fix overwriting built-in commands https://github.com/cypress-io/cypress/issues/22733
