### PR TITLE
Bump npm release to v2 branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Publish Releases
-      uses: thefrontside/actions/synchronize-with-npm@v1.9
+      uses: thefrontside/actions/synchronize-with-npm@v2
       with:
         before_all: yarn prepack:all
         npm_publish: yarn publish


### PR DESCRIPTION
## Motivation

I noticed that we're still using 1.9 for syncronize-npm

## Approach

Change version to v2