### PR TITLE
bump @testing-library/dom to v8.18.1

### DIFF
--- a/.changeset/lovely-elephants-beam.md
+++ b/.changeset/lovely-elephants-beam.md
@@ -1,0 +1,5 @@
+---
+"@interactors/core": patch
+---
+
+bump @testing-library/dom to v8.18.1 fixes https://github.com/thefrontside/interactors/issues/212

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@effection/core": "2.2.0",
     "@interactors/globals": "1.0.0-rc1.2",
-    "@testing-library/dom": "^8.5.0",
+    "@testing-library/dom": "^8.18.1",
     "@testing-library/user-event": "^13.2.1",
     "change-case": "^4.1.1",
     "element-is-visible": "^1.0.0",


### PR DESCRIPTION
## Motivation

The `8.18.0` release of `@testing-library/dom` is buggy and doesn't play nice with Cypress.

## Approach

Bump the minimum version of `@testing-library/dom` from `^8.5.0` to `^8.18.1`, which is semver-compatible with the previous dependency while avoiding the broken version.

Fixes #212
