### PR TITLE
Use volta-cli github action

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: volta-cli/action@v3
+        with:
+          registry-url: https://registry.npmjs.org
       - name: Install Dependencies
         run: yarn
       - name: Create Release Pull Request

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - uses: actions/setup-node@v2
+    - uses: volta-cli/action@v3
       with:
         registry-url: https://registry.npmjs.org
     - name: Publish PR Preview


### PR DESCRIPTION
## Motivation

`yarn install` fails on main branch in GitHub actions for some reason

## Approach

Tried to keep nodejs/yarn version from `Volta` settings in package.json
