### PR TITLE
Fix typechecking for interactors/core

### DIFF
--- a/.changeset/popular-geese-bow.md
+++ b/.changeset/popular-geese-bow.md
@@ -1,0 +1,5 @@
+---
+"@interactors/core": patch
+---
+
+Fix type checking

--- a/packages/core/src/inspector.ts
+++ b/packages/core/src/inspector.ts
@@ -31,7 +31,7 @@ export function createInspector<IC extends InteractorConstructor<any, any, any, 
       let elements = findElements<GetElement<IC>>(parentElement ?? unsafeSyncResolveParent(options), options);
       return elements.map(
         element => (Object.assign(
-          instantiateInteractor(options, () => element) as (Interactor<GetElement<IC>, Filters<GetFilters<IC>>> & GetActions<IC>), {
+          instantiateInteractor(options, () => element) as unknown as (Interactor<GetElement<IC>, Filters<GetFilters<IC>>> & GetActions<IC>), {
           element,
           find<T extends InteractorConstructor<any, any, any, any>>(constructor: T): Inspector<T> {
             return createInspector(constructor, element)


### PR DESCRIPTION
## Motivation

Hm... some strange thing happened. The release couldn't be published because of build error and there is no fail in GitHub Actions. I checked on a fresh repo and `yarn prepack` doesn't produce that error, but I have it in vscode
<img width="1757" alt="Screenshot 2023-09-01 at 12 21 44" src="https://github.com/thefrontside/interactors/assets/6397708/a3c62034-de0f-4e91-ab8f-c872a0f80d47">

## Approach

Fix type checking error
