### PR TITLE
Don't break every input field if there is an aria labelled input

### DIFF
--- a/.changeset/form-field-arial-labels.md
+++ b/.changeset/form-field-arial-labels.md
@@ -1,0 +1,4 @@
+---
+"@interactors/html": patch
+---
+Lookup Interactor by ARIA label if it is present

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "@typescript-eslint/utils": "^7.7.1",
     "eslint": "^8.56.0",
     "node-gyp": "^10.1.0",
-    "patch-package": "^6.4.7"
+    "patch-package": "^6.4.7",
+    "typescript-language-server": "^4.3.3"
   },
   "resolutions": {
     "@definitelytyped/typescript-versions": "^0.0.40",

--- a/packages/html/test/text-field.test.ts
+++ b/packages/html/test/text-field.test.ts
@@ -7,7 +7,7 @@ describe('@interactors/html', () => {
   describe('TextField', () => {
     it('finds `input` tags without type by label', async () => {
       dom(`
-        <label for="name-field">Name</label><input id="name-field"/>
+	<label for="name-field">Name</label><input id="name-field"/>
       `);
 
       await expect(TextField('Name').exists()).resolves.toBeUndefined();
@@ -16,7 +16,7 @@ describe('@interactors/html', () => {
 
     it('finds `input[type=text]` tags by label', async () => {
       dom(`
-        <label for="name-field">Name</label><input type="text" id="name-field"/>
+	<label for="name-field">Name</label><input type="text" id="name-field"/>
       `);
 
       await expect(TextField('Name').exists()).resolves.toBeUndefined();
@@ -25,17 +25,24 @@ describe('@interactors/html', () => {
 
     it('finds `textarea` tags by label', async () => {
       dom(`
-        <label for="name-field">Name</label>
-        <textarea id="name-field"></textarea>
+	<label for="name-field">Name</label>
+	<textarea id="name-field"></textarea>
       `);
 
       await expect(TextField('Name').exists()).resolves.toBeUndefined();
       await expect(TextField('Does not Exist').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
     });
 
+    it('finds `input` tags with an aria-label', async () => {
+      dom(`
+        <input type="text" aria-label="Name">
+`);
+      await expect(TextField("Name").exists()).resolves.toBeUndefined();
+    })
+
     it('finds `input` tags with custom type', async () => {
       dom(`
-        <label for="name-field">Name</label><input type="monkey" id="name-field"/>
+	<label for="name-field">Name</label><input type="monkey" id="name-field"/>
       `);
 
       await expect(TextField('Name').exists()).resolves.toBeUndefined();
@@ -44,7 +51,7 @@ describe('@interactors/html', () => {
 
     it('does not find non text field inputs', async () => {
       dom(`
-        <label for="name-field">Name</label><input type="range" id="name-field"/>
+	<label for="name-field">Name</label><input type="range" id="name-field"/>
       `);
 
       await expect(TextField('Name').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
@@ -52,9 +59,9 @@ describe('@interactors/html', () => {
 
     it('does not yet support multiple label tags per `input`, becomes rejected as ambiguous', async () => {
       dom(`
-        <label for="name-field">Name</label>
-        <label for="name-field">Designation</label>
-        <input id="name-field"/>
+	<label for="name-field">Name</label>
+	<label for="name-field">Designation</label>
+	<input id="name-field"/>
       `);
 
       await expect(TextField('Name').exists()).rejects.toHaveProperty('name', 'AmbiguousElementError');
@@ -62,168 +69,168 @@ describe('@interactors/html', () => {
 
     describe('.click', () => {
       it('clicks on field', async () => {
-        dom(`
-          <p>
-            <label for="nameField">Name</label>
-            <input type="text" id="nameField"/>
-            <h1 id="target"></h1>
-          </p>
-          <script>
-            nameField.addEventListener('click', (event) => target.textContent = 'Success');
-          </script>
-        `);
+	dom(`
+	  <p>
+	    <label for="nameField">Name</label>
+	    <input type="text" id="nameField"/>
+	    <h1 id="target"></h1>
+	  </p>
+	  <script>
+	    nameField.addEventListener('click', (event) => target.textContent = 'Success');
+	  </script>
+	`);
 
-        await TextField('Name').click();
-        await Heading('Success').exists();
+	await TextField('Name').click();
+	await Heading('Success').exists();
       });
     });
 
     describe('.focus', () => {
       it('focuses on field', async () => {
-        dom(`
-          <p>
-            <label for="nameField">Name</label>
-            <input type="text" id="nameField"/>
-            <h1 id="target"></h1>
-          </p>
-          <script>
-            nameField.addEventListener('focus', (event) => target.textContent = 'Success');
-          </script>
-        `);
+	dom(`
+	  <p>
+	    <label for="nameField">Name</label>
+	    <input type="text" id="nameField"/>
+	    <h1 id="target"></h1>
+	  </p>
+	  <script>
+	    nameField.addEventListener('focus', (event) => target.textContent = 'Success');
+	  </script>
+	`);
 
-        await TextField('Name').focus();
-        await TextField('Name').is({ focused: true });
-        await Heading('Success').exists();
+	await TextField('Name').focus();
+	await TextField('Name').is({ focused: true });
+	await Heading('Success').exists();
       });
     });
 
     describe('.blur', () => {
       it('blurs field', async () => {
-        dom(`
-          <p>
-            <label for="nameField">Name</label>
-            <input type="text" id="nameField"/>
-            <h1 id="target"></h1>
-          </p>
-          <script>
-            nameField.addEventListener('blur', (event) => target.textContent = 'Success');
-          </script>
-        `);
+	dom(`
+	  <p>
+	    <label for="nameField">Name</label>
+	    <input type="text" id="nameField"/>
+	    <h1 id="target"></h1>
+	  </p>
+	  <script>
+	    nameField.addEventListener('blur', (event) => target.textContent = 'Success');
+	  </script>
+	`);
 
-        await TextField('Name').focus();
-        await TextField('Name').blur();
-        await TextField('Name').is({ focused: false });
-        await Heading('Success').exists();
+	await TextField('Name').focus();
+	await TextField('Name').blur();
+	await TextField('Name').is({ focused: false });
+	await Heading('Success').exists();
       });
     });
 
     describe('.fillIn', () => {
       it('fills in the field', async () => {
-        dom(`
-          <p>
-            <label for="nameField">Name</label>
-            <input type="text" id="nameField"/>
-          </p>
-        `);
+	dom(`
+	  <p>
+	    <label for="nameField">Name</label>
+	    <input type="text" id="nameField"/>
+	  </p>
+	`);
 
-        await TextField('Name').fillIn('John');
-        await TextField('Name').has({ value: 'John' });
+	await TextField('Name').fillIn('John');
+	await TextField('Name').has({ value: 'John' });
       });
     });
 
     describe('filter `title`', () => {
       it('filters `input` tags by their title', async () => {
-        dom(`
-          <p>
-            <label for="name-field">Name</label>
-            <input id="name-field" type="text" title="My Name Field"/>
-          </p>
-        `);
+	dom(`
+	  <p>
+	    <label for="name-field">Name</label>
+	    <input id="name-field" type="text" title="My Name Field"/>
+	  </p>
+	`);
 
-        await expect(TextField('Name', { title: 'My Name Field' }).exists()).resolves.toBeUndefined();
-        await expect(TextField('Name', { title: 'Does not exist' }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+	await expect(TextField('Name', { title: 'My Name Field' }).exists()).resolves.toBeUndefined();
+	await expect(TextField('Name', { title: 'Does not exist' }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
       });
     });
 
     describe('filter `disabled`', () => {
       it('filters `input` tags by their disabled state', async () => {
-        dom(`
-          <p><input id="name-field" disabled/></p>
-          <p><input id="address-field"/></p>
-        `);
+	dom(`
+	  <p><input id="name-field" disabled/></p>
+	  <p><input id="address-field"/></p>
+	`);
 
-        await expect(TextField({ id: 'name-field', disabled: true }).exists()).resolves.toBeUndefined();
-        await expect(TextField({ id: 'address-field', disabled: false }).exists()).resolves.toBeUndefined();
-        await expect(TextField({ id: 'name-field', disabled: false }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
-        await expect(TextField({ id: 'address-field', disabled: true }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+	await expect(TextField({ id: 'name-field', disabled: true }).exists()).resolves.toBeUndefined();
+	await expect(TextField({ id: 'address-field', disabled: false }).exists()).resolves.toBeUndefined();
+	await expect(TextField({ id: 'name-field', disabled: false }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+	await expect(TextField({ id: 'address-field', disabled: true }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
       });
 
       it('defaults to only enabled', async () => {
-        dom(`
-          <p><input id="name-field" disabled/></p>
-          <p><input id="address-field"/></p>
-        `);
+	dom(`
+	  <p><input id="name-field" disabled/></p>
+	  <p><input id="address-field"/></p>
+	`);
 
-        await expect(TextField({ id: 'address-field' }).exists()).resolves.toBeUndefined();
-        await expect(TextField({ id: 'name-field' }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+	await expect(TextField({ id: 'address-field' }).exists()).resolves.toBeUndefined();
+	await expect(TextField({ id: 'name-field' }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
       });
     });
 
     describe('filter `id`', () => {
       it('filters `input` tags by id', async () => {
-        dom(`
-          <p>
-            <label for="name-field">Name</label>
-            <input id="name-field"/>
-          </p>
-        `);
+	dom(`
+	  <p>
+	    <label for="name-field">Name</label>
+	    <input id="name-field"/>
+	  </p>
+	`);
 
-        await expect(TextField('Name', { id: 'name-field' }).exists()).resolves.toBeUndefined();
-        await expect(TextField('Name', { id: 'does-not-exist' }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+	await expect(TextField('Name', { id: 'name-field' }).exists()).resolves.toBeUndefined();
+	await expect(TextField('Name', { id: 'does-not-exist' }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
       });
     });
 
     describe('filter `value`', () => {
       it('filters `input` tags by value', async () => {
-        dom(`
-          <p>
-            <label for="name-field">Name</label>
-            <input id="name-field" value="John"/>
-          </p>
-        `);
+	dom(`
+	  <p>
+	    <label for="name-field">Name</label>
+	    <input id="name-field" value="John"/>
+	  </p>
+	`);
 
-        await expect(TextField('Name', { value: 'John' }).exists()).resolves.toBeUndefined();
-        await expect(TextField('Name', { value: 'Does not Exist' }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+	await expect(TextField('Name', { value: 'John' }).exists()).resolves.toBeUndefined();
+	await expect(TextField('Name', { value: 'Does not Exist' }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
       });
     });
 
     describe('filter `placeholder`', () => {
       it('filters `input` tags by placeholder', async () => {
-        dom(`
-          <p>
-            <label for="name-field">Name</label>
-            <input id="name-field" placeholder="Your Name"/>
-          </p>
-        `);
+	dom(`
+	  <p>
+	    <label for="name-field">Name</label>
+	    <input id="name-field" placeholder="Your Name"/>
+	  </p>
+	`);
 
-        await expect(TextField('Name', { placeholder: 'Your Name' }).exists()).resolves.toBeUndefined();
-        await expect(TextField('Name', { placeholder: 'Does not Exist' }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+	await expect(TextField('Name', { placeholder: 'Your Name' }).exists()).resolves.toBeUndefined();
+	await expect(TextField('Name', { placeholder: 'Does not Exist' }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
       });
     });
 
     describe('filter `valid`', () => {
       it('filters `input` tags by their validity state', async () => {
-        dom(`
-          <p>
-            <input required id="name-field" value="John"/>
-            <input required id="address-field"/>
-          </p>
-        `);
+	dom(`
+	  <p>
+	    <input required id="name-field" value="John"/>
+	    <input required id="address-field"/>
+	  </p>
+	`);
 
-        await expect(TextField({ id: 'name-field', valid: true }).exists()).resolves.toBeUndefined();
-        await expect(TextField({ id: 'address-field', valid: false }).exists()).resolves.toBeUndefined();
-        await expect(TextField({ id: 'name-field', valid: false }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
-        await expect(TextField({ id: 'address-field', valid: true }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+	await expect(TextField({ id: 'name-field', valid: true }).exists()).resolves.toBeUndefined();
+	await expect(TextField({ id: 'address-field', valid: false }).exists()).resolves.toBeUndefined();
+	await expect(TextField({ id: 'name-field', valid: false }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+	await expect(TextField({ id: 'address-field', valid: true }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
       });
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -14614,6 +14614,7 @@ __metadata:
     eslint: "npm:^8.56.0"
     node-gyp: "npm:^10.1.0"
     patch-package: "npm:^6.4.7"
+    typescript-language-server: "npm:^4.3.3"
   languageName: unknown
   linkType: soft
 
@@ -23683,6 +23684,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript-language-server@npm:^4.3.3":
+  version: 4.3.3
+  resolution: "typescript-language-server@npm:4.3.3"
+  bin:
+    typescript-language-server: lib/cli.mjs
+  checksum: 10c0/c4b599005f631438d46dc39dcdf148a816dcde98eece17e9888eae3558f2cf8004e53ee3853f88abb78bfa9b5428cf100b6f061c2463c435d2cfe5db0f9f57a1
+  languageName: node
+  linkType: hard
+
 "typescript@npm:^5.4.5":
   version: 5.4.5
   resolution: "typescript@npm:5.4.5"
@@ -24376,6 +24386,37 @@ __metadata:
   version: 1.1.2
   resolution: "vm-browserify@npm:1.1.2"
   checksum: 10c0/0cc1af6e0d880deb58bc974921320c187f9e0a94f25570fca6b1bd64e798ce454ab87dfd797551b1b0cc1849307421aae0193cedf5f06bdb5680476780ee344b
+  languageName: node
+  linkType: hard
+
+"vscode-jsonrpc@npm:8.2.0":
+  version: 8.2.0
+  resolution: "vscode-jsonrpc@npm:8.2.0"
+  checksum: 10c0/0789c227057a844f5ead55c84679206227a639b9fb76e881185053abc4e9848aa487245966cc2393fcb342c4541241b015a1a2559fddd20ac1e68945c95344e6
+  languageName: node
+  linkType: hard
+
+"vscode-jsonrpc@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "vscode-jsonrpc@npm:5.0.1"
+  checksum: 10c0/365dc54648247f0eb31ffdeb45b67c17f2cfac6cf55810b52376bad0becc7ee029dbe722e8d94fc779217e012466e8f7c7360749667946ff4e1156731abe1941
+  languageName: node
+  linkType: hard
+
+"vscode-languageserver-protocol@npm:^3.15.0":
+  version: 3.17.5
+  resolution: "vscode-languageserver-protocol@npm:3.17.5"
+  dependencies:
+    vscode-jsonrpc: "npm:8.2.0"
+    vscode-languageserver-types: "npm:3.17.5"
+  checksum: 10c0/5f38fd80da9868d706eaa4a025f4aff9c3faad34646bcde1426f915cbd8d7e8b6c3755ce3fef6eebd256ba3145426af1085305f8a76e34276d2e95aaf339a90b
+  languageName: node
+  linkType: hard
+
+"vscode-languageserver-types@npm:3.17.5":
+  version: 3.17.5
+  resolution: "vscode-languageserver-types@npm:3.17.5"
+  checksum: 10c0/1e1260de79a2cc8de3e46f2e0182cdc94a7eddab487db5a3bd4ee716f67728e685852707d72c059721ce500447be9a46764a04f0611e94e4321ffa088eef36f8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Motivation

https://github.com/thefrontside/interactors/issues/254

## Approach

This unrolls the locator for form fields to not require a corresponding `label` element. If it has and `aria-label` attribute, or it has a placeholder, that can be used as the locator.

### TODOs and Open Questions

- [ ] Should we include the `placeholder` text? It would be weird if you had an element with a placeholder and then you added a label, and all of a sudden in changed its interaction match.

## Learning

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label