### PR TITLE
Sign Commits for the changeset with bot credentials

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -16,6 +16,15 @@ jobs:
           registry-url: https://registry.npmjs.org
       - name: Install Dependencies
         run: yarn
+
+      - name: Commit Signing
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.FRONTSIDEJACK_GPG_KEY }}
+          passphrase: ${{ secrets.FRONTSIDEJACK_GPG_KEY_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
       - name: Create Release Pull Request
         uses: changesets/action@master
         with:


### PR DESCRIPTION
## Motivation

We don't allow unverified commits as part of our branch protection rules. However, our PR workflow creates a commit with the version bumps and changelog entries. This blocks release.

## Approach

Follow the instructions for Option (2) here https://github.com/Nautilus-Cyberneering/pygithub/blob/main/docs/how_to_sign_automatic_commits_in_github_actions.md

## Learning

https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits