### PR TITLE
Make sure to run yarn install after creating a changeset version

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -30,5 +30,6 @@ jobs:
         with:
           commit: "Version packages"
           title: "Version packages"
+          version: yarn changeset version && yarn install
         env:
           GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation

Our tests assume a frozen lockfile and will fail without it. https://github.com/thefrontside/interactors/actions/runs/9021636078/job/24789386061?pr=253

However, when we bump the package versions as part of the changset versioning, this necessarily means that the yarn lock will be different than before and want to be generated anew. This causes the tests to fail on the release PR always.

I'm not exactly sure why this started failing now, but this might have something to do with yarn 4 handling stuff differently than in yarn 1, but it does make sense as a matter of principal.

## Approach

This overrides the `version` script in the changeset action to first invoke the original `changeset version` command, and then to run an yarn install. That way, the new lock file will be generated as part of the release commit.

## Learning

https://github.com/changesets/action?tab=readme-ov-file#with-version-script