### PR TITLE
bring version script in-house

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -30,6 +30,6 @@ jobs:
         with:
           commit: "Version packages"
           title: "Version packages"
-          version: yarn changeset version && yarn install
+          version: yarn changeset:version
         env:
           GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     ]
   },
   "scripts": {
+    "changeset:version": "changeset version && yarn install",
     "clean": "find . \\( -name node_modules -o -name dist -o -name '*.tsbuildinfo' \\) -exec rm -rf {} +",
     "clean:tsc": "find . \\( -path node_modules -prune -name dist -o -name '*.tsbuildinfo' \\) -exec rm -rf {} +",
     "clean:tsbuild": "find . -path -o -name '*.tsbuildinfo' -delete",


### PR DESCRIPTION
## Motivation

It appears that the version script is not interpreted by a shell, but is instead treaded as a single command. Thus changeset is receiving everything.

## Approach

Follow the recommendations and bring the script into the `yarn` scripts file. That way, yarn WILL shell out to it.