### PR TITLE
🐛 bump new release in order to push DNT packages

### DIFF
--- a/.changes/fix-types.md
+++ b/.changes/fix-types.md
@@ -1,0 +1,8 @@
+---
+"@effection/globals": patch
+"@effection/core": patch
+"@effection/html": patch
+"@effection/keyboard": patch
+---
+
+Fix types in distributed NPM packages which were being incorrectly referenced in the package exports.

--- a/.changes/fix-types.md
+++ b/.changes/fix-types.md
@@ -1,8 +1,8 @@
 ---
-"@effection/globals": patch
-"@effection/core": patch
-"@effection/html": patch
-"@effection/keyboard": patch
+"@interactors/globals": patch
+"@interactors/core": patch
+"@interactors/html": patch
+"@interactors/keyboard": patch
 ---
 
 Fix types in distributed NPM packages which were being incorrectly referenced in the package exports.

--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,8 @@
-node_modules
-yarn-error.log
-/packages/*/dist
 /packages/*/build
-/packages/*/docs
-*.tsbuildinfo
+
 .node-version
 
 # Local Netlify folder
 .netlify
 
 .vscode
-# yarn v2
-.yarn/cache
-.yarn/unplugged
-.yarn/build-state.yml
-.yarn/install-state.gz
-.pnp.*
-__generated__
-.parcel-cache


### PR DESCRIPTION
## Motivation

One of the reasons that we're migrating to Deno is that our current process releases bad types for our packages. Instead, we want to leave off trying to hand roll a bunch of package.json and tsconfigs, and instead generate well-formed NPM packages by default with an automated tool like DNT. Now that we're migrated to Deno, we can fix those types.

## Approach

Make some trivial changes, and bump the versions for all the packages.