### PR TITLE
👷 Use Jack's PAT when creating release pull request

### DIFF
--- a/.github/workflows/covector-comment-on-form.yml
+++ b/.github/workflows/covector-comment-on-form.yml
@@ -26,5 +26,5 @@ jobs:
       - name: covector status
         uses: jbolda/covector/packages/action@covector-v0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
           command: "status"

--- a/.github/workflows/covector-version-or-release.yml
+++ b/.github/workflows/covector-version-or-release.yml
@@ -36,6 +36,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         if: steps.covector.outputs.commandRan == 'version'
         with:
+          token: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
           title: "Publish New Versions"
           commit-message: "publish new versions"
           labels: "version updates"


### PR DESCRIPTION
## Motivation
As a rule we use Jack as our default choice for automation because unlike the standard github actions bot:

1. It's cooler.
2. It allows workflows to be triggered whenever he takes an action

For example, without using Jack, we would not be able to have another workflow begin as a result of the release pull request being opened.

## Approach

Pass his github token on to the pull request action.