### PR TITLE
👷 Sign release commits with Jack's token

### DIFF
--- a/.github/workflows/covector-version-or-release.yml
+++ b/.github/workflows/covector-version-or-release.yml
@@ -32,6 +32,12 @@ jobs:
           token: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
           command: "version-or-publish"
           recognizeContributors: true
+
+        # recommit with the signature setup in the beginning of this action
+      - name: Sign Commits
+        if: steps.covector.outputs.commandRan == 'version'
+        run: git commit --amend --no-edit --reset-author
+
       - name: Create Pull Request With Versions Bumped
         uses: peter-evans/create-pull-request@v6
         if: steps.covector.outputs.commandRan == 'version'


### PR DESCRIPTION
## Motivation
We have a requirement that all repository commits be signed. This means that automations should also sign commits.

## Approach

We are setting up commit signing in the repository, but there is no way (that I know of) to currently pass that git config into the container in which covector is running its action.

This checks which action covector ran and then if it is `version`, re-commits HEAD which is configured to use Jack's credentials and config.