### PR TITLE
👷 Make Jack both author AND committer of release PR commits.

### DIFF
--- a/.github/workflows/covector-version-or-release.yml
+++ b/.github/workflows/covector-version-or-release.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           token: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
           title: "Publish New Versions"
+          author: Jack <jack@frontside.com>
           committer: Jack <jack@frontside.com>
           commit-message: "publish new versions"
           labels: "version updates"


### PR DESCRIPTION
## Motivation

Co-authored commits are not fully verifiable, therefore the PR commit is listed as "partially verified".

## Approach
This makes Jack both author _and_ committer, that way, the commit can be fully verified.