### PR TITLE
👷 Match scoped packages for NPM publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Publish
 on:
   push:
     tags:
-      - "*-v*"
+      - "**-v*"
 
 jobs:
   publish-to-npm:


### PR DESCRIPTION
## Motivation

According to the [github docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet) `*` will match multiple characters but not `/` which means `*-v*` will not match `@interactors/html-v1.0.1`

## Approach

Match the package name with `**`
