### PR TITLE
👷 Bypass tag filtering for the release pattern and conditionally run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,11 @@ name: Publish
 on:
   push:
     tags:
-      - "**-v*"
+      - '**'
 
 jobs:
   publish-to-npm:
+    if: "startsWith(github.ref, 'refs/tags/@interactors')"
     name: NPM ${{ github.ref }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Motivation

Workflows don't seem to run when our tags are pushed. Maybe it's the filters

## Approach

Let's doing a manual match with an if statement. At least it will confirm that the workflow is running.
