### PR TITLE
👷 remove special characters from release tags.

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -3,9 +3,9 @@
   "pkgManagers": {
     "javascript": {
       "version": true,
-      "getPublishedVersion": "git tag -l \"${ pkg.pkg }-v${ pkgFile.version }\" | sed 's/.*-v//'",
+      "getPublishedVersion": "git tag -l \"${ pkg.pkg.replace(`@interactors/`,`interactors-`) }-v${ pkgFile.version }\" | sed 's/.*-v//'",
       "publish": [
-        "git tag -a -m \"${ pkg.pkg }-v${ pkgFile.version }\" ${ pkg.pkg }-v${ pkgFile.version }"
+        "git tag -a -m '${ pkg.pkg }-v${ pkgFile.version}' ${ pkg.pkg.replace(`@interactors/`,`interactors-`) }-v${ pkgFile.version }"
       ]
     }
   },

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,10 @@ name: Publish
 on:
   push:
     tags:
-      - '**'
+      - '**-v*'
 
 jobs:
   publish-to-npm:
-    if: startsWith(github.ref, 'refs/tags/@interactors')
     name: NPM ${{ github.ref }}
     runs-on: ubuntu-latest
     steps:

--- a/tasks/context-from-git-tag.ts
+++ b/tasks/context-from-git-tag.ts
@@ -14,7 +14,7 @@ export async function deriveFromGitTag([argName, gitTag]: [
   const { default: covectorConfig } = await import("../.changes/config.json", {
     with: { type: "json" },
   });
-  const [pkg, _] = gitTag.replace("refs/tags/", "").split("-v");
+  const [pkg, _] = gitTag.replace("refs/tags/interactors-", "@interactors/").split("-v");
   // @ts-expect-error let's undefined check
   const pkgConfig = covectorConfig.packages[pkg];
   if (!pkgConfig) throw new Error(`${pkg} not defined in .changes/config.json`);


### PR DESCRIPTION
## Motivation

Our current working theory is that tags of the form `@interactors/html-v1.0.1` do not trigger workflows that match any tag. We've tried using this manually pushing the tags and it is still not triggering the workflow.

This replaces the `@interactors/` portion of each tag with `interactors-` so that:

```
@interactors/html-v1.0.0
```

Is represented as:

```
interactors-html-v1.0.0
```