### PR TITLE
👷 Add permissions to NPM publish with provenance

### DIFF
--- a/.github/workflows/covector-version-or-release.yml
+++ b/.github/workflows/covector-version-or-release.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  actions: write
+  pull-requests: write
+
 jobs:
   version-or-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "interactors-*"
 
+permissions:
+  id-token: write
+  contents: read
+
+
 jobs:
   publish-to-npm:
     name: NPM ${{ github.ref }}


### PR DESCRIPTION
## Motivation

NPM Release action is failing because of insufficient permissions.