### PR TITLE
✨ Add sitemap.xml to interactors site.

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -1,0 +1,29 @@
+name: Website
+
+on:
+  push:
+    branches:
+      - main
+      - www # remove this branch once this is merged to main
+    paths:
+      - website/**
+
+jobs:
+  website:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: volta-cli/action@v4
+
+      - run: yarn install && yarn build
+        working-directory: website
+
+      - uses: denoland/deployctl@v1
+        with:
+          project: interactors
+          entrypoint: https://deno.land/std@0.224.0/http/file_server.ts
+          root: website/build

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -11,3 +11,4 @@ build
 docs/**/api
 sidebars
 public
+/node_modules

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   title: "Interactors",
   tagline: "Page Objects for components libraries",
-  url: "https://frontside.com/",
+  url: "https://interactors.deno.dev",
   baseUrl: "/interactors/",
   onBrokenLinks: "throw",
   favicon: "images/favicon-interactors.png",
@@ -119,6 +119,7 @@ module.exports = {
         theme: {
           customCss: require.resolve("./src/css/custom.css"),
         },
+	sitemap: {}
       },
     ],
   ],

--- a/website/package.json
+++ b/website/package.json
@@ -4,10 +4,8 @@
   "private": true,
   "scripts": {
     "start": "docusaurus start",
-    "build": "docusaurus build --out-dir public/interactors",
-    "swizzle": "docusaurus swizzle",
-    "deploy": "docusaurus deploy",
-    "serve": "docusaurus serve --dir public/interactors"
+    "build": "docusaurus build --out-dir build/interactors && node sitemap.mjs",
+    "serve": "docusaurus serve"
   },
   "dependencies": {
     "@docusaurus/core": "2.0.0-beta.9",
@@ -21,7 +19,8 @@
     "email-validator": "^2.0.4",
     "jsonp": "^0.2.1",
     "react": "^16.8.4",
-    "react-dom": "^16.8.4"
+    "react-dom": "^16.8.4",
+    "xml2js": "^0.6.2"
   },
   "browserslist": {
     "production": [
@@ -34,5 +33,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "volta": {
+    "node": "16.20.2",
+    "yarn": "1.22.22"
   }
 }

--- a/website/sitemap.mjs
+++ b/website/sitemap.mjs
@@ -1,0 +1,58 @@
+/* Add indexes of all dynamically loaded assets so that they can be staticalized */
+
+import { readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { Parser, Builder } from "xml2js";
+
+const [parser, builder] = [new Parser(), new Builder()];
+
+const sitemapXML = readFileSync("./build/interactors/sitemap.xml");
+
+const sitemap = await parser.parseStringPromise(sitemapXML);
+
+// ideally we would use the docusaurs sitemap plugin to do this
+// but support for plugins came with => 3.0.0 and upgrade no thank you.
+sitemap.urlset.url.push({
+  loc: 'https://interactors.deno.dev/interactors/assets/js/index.html',
+}, {
+  loc: 'https://interactors.deno.dev/interactors/images/index.html'
+});
+
+writeFileSync("./build/interactors/sitemap.xml", builder.buildObject(sitemap));
+
+const assets = readdirSync("./build/interactors/assets/js");
+
+writeFileSync("./build/interactors/assets/js/index.html",`
+<html>
+  <head>
+${assets.map((asset) => `    <link rel="asset" href="${asset}"/>`).join("\n")}
+  </head>
+  <body>
+  <h1> JavaScript Index</h1>
+  <ul>
+
+${assets.map((asset) => `    <li><a href="${asset}">${asset}</a></li>`).join("\n")}
+
+  </ul>
+  <body>
+<html>
+
+`);
+
+const images = readdirSync("./build/interactors/images");
+
+writeFileSync("./build/interactors/images/index.html",`
+<html>
+  <head>
+${images.map((image) => `    <link rel="asset" href="${image}"/>`).join("\n")}
+  </head>
+  <body>
+  <h1> JavaScript Index</h1>
+  <ul>
+
+${images.map((image) => `    <li><a href="${image}">${image}</a></li>`).join("\n")}
+
+  </ul>
+  <body>
+<html>
+
+`);

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2578,7 +2578,7 @@
     "@docusaurus/theme-classic" "2.0.0-beta.9"
     "@docusaurus/theme-search-algolia" "2.0.0-beta.9"
 
-"@docusaurus/react-loadable@5.5.2", "react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+"@docusaurus/react-loadable@5.5.2":
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
   integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
@@ -7825,6 +7825,14 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   dependencies:
     "@babel/runtime" "^7.10.3"
 
+"react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
+  integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
+  dependencies:
+    "@types/react" "*"
+    prop-types "^15.6.2"
+
 react-router-config@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-router-config/-/react-router-config-5.1.1.tgz#0f4263d1a80c6b2dc7b9c1902c9526478194a988"
@@ -8254,6 +8262,11 @@ safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+sax@>=0.6.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.4.1.tgz#44cc8988377f126304d3b3fc1010c733b929ef0f"
+  integrity sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==
 
 sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
@@ -9544,6 +9557,19 @@ xml-js@^1.6.11:
   integrity sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==
   dependencies:
     sax "^1.2.4"
+
+xml2js@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.6.2.tgz#dd0b630083aa09c161e25a4d0901e2b2a929b499"
+  integrity sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xtend@^4.0.0, xtend@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
> 🚚 Heads up! 
> This PR also migrates the interactors to host at Deno Deploy: It turns out that it is very good at it, it's hella cheaper than Netlify, and much, much, much more flexible in how we can extend it. This must be merged first https://github.com/thefrontside/frontside.com/pull/400 which points frontside.com to this new site.

## Motivation

We're going to use sitemaps as a standards based mechanism to compose our websites; thereby decoupling us from any single website content framework.

## Approach

This adds a sitemap for the interactors website so that it can be "mounted" on frontside.com by enabling the docusaurus "sitemap" plugin.

Docusaurus does a bunch of dynamic chicanery with React, Webpack and code-splitting to render a static webpage because _reasons_, so we add a synthetic entries to the sitemap to serve as indexes for all dynamically loaded resources (those resources that are fetched via JavaScript as follow-on requests). That way, the static site capture process can know to download all those resources ahead of time even though they are not referenced directly in any page.

## Screenshots

<img width="665" alt="image" src="https://github.com/user-attachments/assets/27b0ac7c-f5be-4f9a-a063-12de7b059553">
