### PR TITLE
✨ Add typedocs for Interactor API back to the website.

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -4,9 +4,12 @@ on:
   push:
     branches:
       - main
-      - www # remove this branch once this is merged to main
     paths:
       - website/**
+      - packages/**/src/**
+  pull_request:
+    branches:
+      - main
 
 jobs:
   website:

--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,11 @@
   "private": true,
   "scripts": {
     "start": "docusaurus start",
-    "build": "docusaurus build --out-dir build/interactors && node sitemap.mjs",
+    "build": "yarn build:docusaurus && yarn build:typedocs:html && yarn build:typedocs:mui && yarn build:sitemap",
+    "build:docusaurus": "docusaurus build --out-dir build/interactors",
+    "build:sitemap": "node sitemap.mjs",
+    "build:typedocs:html": "cd ../packages/html && npx typedoc --out ../../website/build/interactors/html/api --skipErrorChecking mod.ts",
+    "build:typedocs:mui": "cd ../packages/material-ui && npx typedoc --out ../../website/build/interactors/mui/api --skipErrorChecking mod.ts",
     "serve": "docusaurus serve"
   },
   "dependencies": {
@@ -37,5 +41,8 @@
   "volta": {
     "node": "16.20.2",
     "yarn": "1.22.22"
+  },
+  "devDependencies": {
+    "tinyexec": "^0.3.0"
   }
 }

--- a/website/sitemap.mjs
+++ b/website/sitemap.mjs
@@ -1,5 +1,6 @@
 /* Add indexes of all dynamically loaded assets so that they can be staticalized */
 
+import { x } from "tinyexec";
 import { readFileSync, writeFileSync, readdirSync } from "node:fs";
 import { Parser, Builder } from "xml2js";
 
@@ -16,6 +17,16 @@ sitemap.urlset.url.push({
 }, {
   loc: 'https://interactors.deno.dev/interactors/images/index.html'
 });
+
+
+// add all of the typedoc files to the sitemap.
+const docfiles = x('find', ['build/interactors/html','build/interactors/mui', '-name', '*.html']);
+for await (const filename of docfiles) {
+  const path = filename.replace(/^build/,'');
+  sitemap.urlset.url.push({
+    loc: `https://interactors.deno.dev${path}`,
+  })
+}
 
 writeFileSync("./build/interactors/sitemap.xml", builder.buildObject(sitemap));
 

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -8902,6 +8902,11 @@ tiny-warning@^1.0.0, tiny-warning@^1.0.3:
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
+tinyexec@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.0.tgz#ed60cfce19c17799d4a241e06b31b0ec2bee69e6"
+  integrity sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==
+
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"


### PR DESCRIPTION
## Motivation

With the migration to Deno and Deploy, we lost the typedocs.

## Approach

This uses typedoc to generate the API docs for the core HTML and MUI interactors.

We still haven't solved the problem of how to manage multiple versions at the same time. I have some ideas on how that would work, but until such time, we need to just the the API docs for the latest version up there.

## Screenshots

<img width="641" alt="image" src="https://github.com/user-attachments/assets/2563ecb5-53fc-4d42-9590-dd47e5c19242">
