### PR TITLE
Expose stable Interactor constructor metadata

### DIFF
--- a/.changes/compiler-metadata.md
+++ b/.changes/compiler-metadata.md
@@ -1,0 +1,6 @@
+---
+"@interactors/core": minor
+---
+
+Expose stable metadata and type guards for discovering interactor and matcher
+constructors.

--- a/packages/core/src/constructor.ts
+++ b/packages/core/src/constructor.ts
@@ -24,6 +24,7 @@ import { createInteraction, type AssertionInteraction, type ActionInteraction } 
 import { isMatcher } from './matcher.ts';
 import { matching } from './matchers/matching.ts';
 import { hasMatchMatching, resolveEmpty, resolveFirst, resolveUnique, unsafeSyncResolveParent, unsafeSyncResolveUnique } from './resolvers.ts';
+import { defineInteractorConstructorMetadata } from "./metadata.ts";
 
 const defaultLocator: FilterDefinition<string, Element> = (element) => element.textContent || "";
 
@@ -200,7 +201,7 @@ export function createConstructor<E extends Element, FP extends FilterParams<any
     return instantiateInteractor({ name, specification, filter, locator, ancestors: [] }, unsafeSyncResolveUnique);
   }
 
-  return Object.assign(initInteractor, {
+  let constructor = Object.assign(initInteractor, {
     interactorName: name,
     selector: (value: string): InteractorConstructor<E, FP, FM, AM> => {
       return createConstructor(name, { ...specification, selector: value });
@@ -218,4 +219,12 @@ export function createConstructor<E extends Element, FP extends FilterParams<any
       return createConstructor(newName, specification) as unknown as InteractorConstructor<ER, FP, FM, AM>;
     },
   }) as unknown as InteractorConstructor<E, FP, FM, AM>;
+
+  defineInteractorConstructorMetadata(constructor, {
+    name,
+    actions: Object.keys(specification.actions ?? {}),
+    filters: Object.keys(specification.filters ?? {}),
+  });
+
+  return constructor;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,7 +4,19 @@ export { isInteraction } from './interaction.ts'
 export { createInteractor } from './create-interactor.ts';
 export { createInspector } from './inspector.ts'
 export { isVisible } from 'element-is-visible';
+export { createMatcher } from './matcher.ts';
 export type { Matcher } from './matcher.ts';
+export {
+  CONSTRUCTOR_METADATA_VERSION,
+  getInteractorConstructorMetadata,
+  getMatcherConstructorMetadata,
+  isInteractorConstructor,
+  isMatcherConstructor,
+} from './metadata.ts';
+export type {
+  InteractorConstructorMetadata,
+  MatcherConstructorMetadata,
+} from './metadata.ts';
 
 export { including } from './matchers/including.ts';
 export { matching } from './matchers/matching.ts';

--- a/packages/core/src/matcher.ts
+++ b/packages/core/src/matcher.ts
@@ -1,4 +1,5 @@
 import isEqual from 'lodash.isequal';
+import { defineMatcherConstructorMetadata } from './metadata.ts';
 
 export interface Matcher<T> {
   match(actual: T): boolean;
@@ -7,6 +8,17 @@ export interface Matcher<T> {
 }
 
 export type MaybeMatcher<T> = Matcher<T> | T;
+
+/**
+ * Create a matcher constructor that can be discovered by build tools.
+ */
+export function createMatcher<F extends (...args: any[]) => Matcher<any>>(
+  name: string,
+  constructor: F,
+): F {
+  defineMatcherConstructorMetadata(constructor, { name });
+  return constructor;
+}
 
 export function isMatcher<T>(value: MaybeMatcher<T>): value is Matcher<T> {
   return value && typeof (value as Matcher<T>).match === 'function' && typeof (value as Matcher<T>).description === 'function';

--- a/packages/core/src/matchers/and.ts
+++ b/packages/core/src/matchers/and.ts
@@ -1,4 +1,4 @@
-import { type Matcher, type MaybeMatcher, matcherDescription, applyMatcher, matcherCode } from '../matcher.ts';
+import { type Matcher, type MaybeMatcher, matcherDescription, applyMatcher, matcherCode, createMatcher } from '../matcher.ts';
 
 export function and<T>(...args: MaybeMatcher<T>[]): Matcher<T> {
   return {
@@ -13,3 +13,5 @@ export function and<T>(...args: MaybeMatcher<T>[]): Matcher<T> {
     }
   }
 }
+
+createMatcher('and', and);

--- a/packages/core/src/matchers/every.ts
+++ b/packages/core/src/matchers/every.ts
@@ -1,4 +1,4 @@
-import { type Matcher, type MaybeMatcher, applyMatcher, matcherDescription, matcherCode } from '../matcher.ts';
+import { type Matcher, type MaybeMatcher, applyMatcher, matcherDescription, matcherCode, createMatcher } from '../matcher.ts';
 
 export function every<T>(expected: MaybeMatcher<T>): Matcher<Iterable<T>> {
   return {
@@ -13,3 +13,5 @@ export function every<T>(expected: MaybeMatcher<T>): Matcher<Iterable<T>> {
     }
   }
 }
+
+createMatcher('every', every);

--- a/packages/core/src/matchers/including.ts
+++ b/packages/core/src/matchers/including.ts
@@ -1,4 +1,4 @@
-import { type Matcher, matcherCode} from '../matcher.ts';
+import { type Matcher, matcherCode, createMatcher } from '../matcher.ts';
 
 export function including(subString: string): Matcher<string> {
   return {
@@ -13,3 +13,5 @@ export function including(subString: string): Matcher<string> {
     }
   }
 }
+
+createMatcher('including', including);

--- a/packages/core/src/matchers/matching.ts
+++ b/packages/core/src/matchers/matching.ts
@@ -1,4 +1,4 @@
-import { type Matcher, matcherCode } from '../matcher.ts';
+import { type Matcher, matcherCode, createMatcher } from '../matcher.ts';
 
 export function matching(regexp: RegExp): Matcher<string> {
   return {
@@ -13,3 +13,5 @@ export function matching(regexp: RegExp): Matcher<string> {
     }
   }
 }
+
+createMatcher('matching', matching);

--- a/packages/core/src/matchers/not.ts
+++ b/packages/core/src/matchers/not.ts
@@ -1,4 +1,4 @@
-import { type Matcher, type MaybeMatcher, matcherDescription, applyMatcher, matcherCode } from '../matcher.ts';
+import { type Matcher, type MaybeMatcher, matcherDescription, applyMatcher, matcherCode, createMatcher } from '../matcher.ts';
 
 export function not<T>(matcher: MaybeMatcher<T>): Matcher<T> {
   return {
@@ -13,3 +13,5 @@ export function not<T>(matcher: MaybeMatcher<T>): Matcher<T> {
     }
   }
 }
+
+createMatcher('not', not);

--- a/packages/core/src/matchers/or.ts
+++ b/packages/core/src/matchers/or.ts
@@ -1,4 +1,4 @@
-import { type Matcher, type MaybeMatcher, matcherDescription, applyMatcher, matcherCode } from '../matcher.ts';
+import { type Matcher, type MaybeMatcher, matcherDescription, applyMatcher, matcherCode, createMatcher } from '../matcher.ts';
 
 export function or<T>(...args: MaybeMatcher<T>[]): Matcher<T> {
   return {
@@ -13,3 +13,5 @@ export function or<T>(...args: MaybeMatcher<T>[]): Matcher<T> {
     }
   }
 }
+
+createMatcher('or', or);

--- a/packages/core/src/matchers/some.ts
+++ b/packages/core/src/matchers/some.ts
@@ -1,4 +1,4 @@
-import { type Matcher, type MaybeMatcher, applyMatcher, matcherDescription, matcherCode } from '../matcher.ts';
+import { type Matcher, type MaybeMatcher, applyMatcher, matcherDescription, matcherCode, createMatcher } from '../matcher.ts';
 
 export function some<T>(expected: MaybeMatcher<T>): Matcher<Iterable<T>> {
   return {
@@ -13,3 +13,5 @@ export function some<T>(expected: MaybeMatcher<T>): Matcher<Iterable<T>> {
     }
   }
 }
+
+createMatcher('some', some);

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -1,0 +1,166 @@
+import type { Matcher } from "./matcher.ts";
+import type { InteractorConstructor } from "./specification.ts";
+
+/**
+ * Version of the metadata attached to interactor and matcher constructors.
+ *
+ * Consumers should use the helpers in this module instead of reading the
+ * symbol properties directly.
+ */
+export const CONSTRUCTOR_METADATA_VERSION = 1 as const;
+
+/** @internal */
+export const INTERACTOR_CONSTRUCTOR_METADATA = Symbol.for(
+  "@interactors/core/interactor-constructor-metadata",
+);
+
+/** @internal */
+export const MATCHER_CONSTRUCTOR_METADATA = Symbol.for(
+  "@interactors/core/matcher-constructor-metadata",
+);
+
+export interface InteractorConstructorMetadata {
+  readonly kind: "interactor";
+  readonly version: typeof CONSTRUCTOR_METADATA_VERSION;
+  readonly name: string;
+  readonly actions: readonly string[];
+  readonly filters: readonly string[];
+}
+
+export interface MatcherConstructorMetadata {
+  readonly kind: "matcher";
+  readonly version: typeof CONSTRUCTOR_METADATA_VERSION;
+  readonly name: string;
+}
+
+type AnyInteractorConstructor = InteractorConstructor<
+  Element,
+  any,
+  any,
+  any
+>;
+
+type AnyMatcherConstructor = (...args: any[]) => Matcher<any>;
+
+/**
+ * Return stable, serializable metadata for an interactor constructor.
+ */
+export function getInteractorConstructorMetadata(
+  value: unknown,
+): InteractorConstructorMetadata | undefined {
+  if (typeof value !== "function") {
+    return undefined;
+  }
+
+  let metadata = Reflect.get(value, INTERACTOR_CONSTRUCTOR_METADATA);
+
+  return isInteractorConstructorMetadata(metadata) ? metadata : undefined;
+}
+
+/**
+ * Determine whether a value was created by {@link createInteractor}.
+ *
+ * The brand uses the global symbol registry so this works when the producer
+ * and consumer load different copies of `@interactors/core`.
+ */
+export function isInteractorConstructor(
+  value: unknown,
+): value is AnyInteractorConstructor {
+  return getInteractorConstructorMetadata(value) !== undefined;
+}
+
+/**
+ * Return stable, serializable metadata for a matcher constructor.
+ */
+export function getMatcherConstructorMetadata(
+  value: unknown,
+): MatcherConstructorMetadata | undefined {
+  if (typeof value !== "function") {
+    return undefined;
+  }
+
+  let metadata = Reflect.get(value, MATCHER_CONSTRUCTOR_METADATA);
+
+  return isMatcherConstructorMetadata(metadata) ? metadata : undefined;
+}
+
+/** Determine whether a value was created by {@link createMatcher}. */
+export function isMatcherConstructor(
+  value: unknown,
+): value is AnyMatcherConstructor {
+  return getMatcherConstructorMetadata(value) !== undefined;
+}
+
+/** @internal */
+export function defineInteractorConstructorMetadata(
+  constructor: Function,
+  metadata: Omit<InteractorConstructorMetadata, "kind" | "version">,
+): void {
+  defineMetadata(constructor, INTERACTOR_CONSTRUCTOR_METADATA, {
+    kind: "interactor",
+    version: CONSTRUCTOR_METADATA_VERSION,
+    name: metadata.name,
+    actions: Object.freeze([...metadata.actions].sort()),
+    filters: Object.freeze([...metadata.filters].sort()),
+  });
+}
+
+/** @internal */
+export function defineMatcherConstructorMetadata(
+  constructor: Function,
+  metadata: Omit<MatcherConstructorMetadata, "kind" | "version">,
+): void {
+  defineMetadata(constructor, MATCHER_CONSTRUCTOR_METADATA, {
+    kind: "matcher",
+    version: CONSTRUCTOR_METADATA_VERSION,
+    name: metadata.name,
+  });
+}
+
+function defineMetadata(
+  constructor: Function,
+  key: symbol,
+  metadata: InteractorConstructorMetadata | MatcherConstructorMetadata,
+): void {
+  Object.defineProperty(constructor, key, {
+    configurable: false,
+    enumerable: false,
+    writable: false,
+    value: Object.freeze(metadata),
+  });
+}
+
+function isInteractorConstructorMetadata(
+  value: unknown,
+): value is InteractorConstructorMetadata {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return value.kind === "interactor" &&
+    value.version === CONSTRUCTOR_METADATA_VERSION &&
+    typeof value.name === "string" &&
+    isStringArray(value.actions) &&
+    isStringArray(value.filters);
+}
+
+function isMatcherConstructorMetadata(
+  value: unknown,
+): value is MatcherConstructorMetadata {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return value.kind === "matcher" &&
+    value.version === CONSTRUCTOR_METADATA_VERSION &&
+    typeof value.name === "string";
+}
+
+function isRecord(value: unknown): value is Record<PropertyKey, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isStringArray(value: unknown): value is readonly string[] {
+  return Array.isArray(value) &&
+    value.every((item) => typeof item === "string");
+}

--- a/packages/core/test/metadata.test.ts
+++ b/packages/core/test/metadata.test.ts
@@ -1,0 +1,72 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import {
+  and,
+  createInteractor,
+  createMatcher,
+  getInteractorConstructorMetadata,
+  getMatcherConstructorMetadata,
+  isInteractorConstructor,
+  isMatcherConstructor,
+  matching,
+} from "../mod.ts";
+
+describe("constructor metadata", () => {
+  it("describes the cumulative filters and actions on an interactor", () => {
+    let FormField = createInteractor("form field")
+      .actions({
+        focus: () => Promise.resolve(),
+      })
+      .filters({
+        value: (element) => element.textContent,
+      })
+      .actions({
+        clear: () => Promise.resolve(),
+      });
+
+    expect(getInteractorConstructorMetadata(FormField)).toEqual({
+      kind: "interactor",
+      version: 1,
+      name: "form field",
+      actions: ["clear", "focus"],
+      filters: ["value"],
+    });
+    expect(isInteractorConstructor(FormField)).toBe(true);
+  });
+
+  it("does not mistake a structurally similar function for an interactor", () => {
+    let similar = Object.assign(() => undefined, {
+      interactorName: "not an interactor",
+      actions: ["click"],
+      filters: ["title"],
+    });
+
+    expect(isInteractorConstructor(similar)).toBe(false);
+    expect(getInteractorConstructorMetadata(similar)).toBeUndefined();
+  });
+
+  it("brands built-in and custom matcher constructors", () => {
+    let custom = createMatcher("custom", (expected: string) => ({
+      match: (actual: string) => actual === expected,
+      description: () => `equal to ${expected}`,
+    }));
+
+    expect(getMatcherConstructorMetadata(matching)).toEqual({
+      kind: "matcher",
+      version: 1,
+      name: "matching",
+    });
+    expect(getMatcherConstructorMetadata(and)).toEqual({
+      kind: "matcher",
+      version: 1,
+      name: "and",
+    });
+    expect(getMatcherConstructorMetadata(custom)).toEqual({
+      kind: "matcher",
+      version: 1,
+      name: "custom",
+    });
+    expect(isMatcherConstructor(custom)).toBe(true);
+    expect(isMatcherConstructor(() => undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Motivation

The compiler and future test-runner adapters need a stable way to discover Interactor and matcher constructors at runtime. Inferring that information from private implementation details or callable shape would make those consumers fragile and tightly coupled to core internals.

## Approach

Attach frozen, versioned metadata to constructors using globally registered symbols. Expose public metadata readers and type guards, populate cumulative action and filter metadata as Interactors are composed, and brand both built-in and custom matcher constructors.

### Alternate Designs

Inspecting function properties or private builder state was considered, but that would couple consumers to implementation details and could incorrectly identify structurally similar functions. A global registry was also avoided because metadata should travel with each constructor and work across duplicate package instances.

### Possible Drawbacks or Risks

The metadata shape becomes a compatibility surface. A metadata version and strict readers make incompatible revisions detectable, while package-qualified global symbol keys reduce collision risk.

### TODOs and Open Questions

None within this layer of the stack.

## Learning

`Symbol.for()` allows independently loaded copies of `@interactors/core` to agree on metadata keys without introducing mutable global registry state.

## Screenshots

Not applicable; this is a runtime API change.
