### PR TITLE
Add the Playwright Interactor adapter

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -19,6 +19,11 @@
       "manager": "javascript",
       "dependencies": ["@interactors/globals"]
     },
+    "@interactors/cli": {
+      "path": "./packages/cli/deno.json",
+      "manager": "javascript",
+      "dependencies": ["@interactors/core"]
+    },
     "@interactors/keyboard": {
       "path": "./packages/keyboard/deno.json",
       "manager": "javascript",
@@ -42,6 +47,11 @@
       "dependencies": ["@interactors/core", "@interactors/globals"],
       "version": false,
       "publish": false
+    },
+    "@interactors/playwright": {
+      "path": "./packages/playwright/deno.json",
+      "manager": "javascript",
+      "dependencies": ["@interactors/core"]
     }
   }
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,4 +27,4 @@ jobs:
 
       - name: Publish Releases
         working-directory: ${{ steps.pkg.outputs.working-directory }}/build/npm
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --tag ${{ steps.pkg.outputs.npm-tag }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,3 +26,21 @@ jobs:
           node packages/cli/build/npm/esm/main.js compile packages/cli/test/fixtures/basic/index.ts --outdir /tmp/interactors-node
           deno run -A packages/cli/build/npm/esm/main.js compile packages/cli/test/fixtures/basic/index.ts --outdir /tmp/interactors-deno
           diff -rq /tmp/interactors-node /tmp/interactors-deno
+
+  playwright:
+    name: Playwright integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - name: Install Chromium
+        working-directory: packages/playwright
+        run: deno task install:browser
+      - name: Run browser integration
+        working-directory: packages/playwright
+        run: deno task test:browser

--- a/deno.json
+++ b/deno.json
@@ -11,6 +11,7 @@
     "./packages/html",
     "./packages/keyboard",
     "./packages/material-ui",
+    "./packages/playwright",
     "./www"
   ],
   "compilerOptions": {

--- a/deno.lock
+++ b/deno.lock
@@ -54,6 +54,7 @@
     "jsr:@std/path@~0.225.2": "0.225.2",
     "jsr:@std/streams@^1.0.14": "1.0.14",
     "jsr:@std/testing@1": "1.0.2",
+    "jsr:@std/yaml@*": "1.1.2",
     "jsr:@ts-morph/bootstrap@0.24": "0.24.0",
     "jsr:@ts-morph/common@0.24": "0.24.0",
     "npm:@effection/core@2.2.0": "2.2.0",
@@ -79,6 +80,7 @@
     "npm:parcel@^2.10.2": "2.12.0_typescript@5.9.3",
     "npm:path-to-regexp@8.2.0": "8.2.0",
     "npm:performance-api@1": "1.0.0",
+    "npm:playwright@1.62.1": "1.62.1",
     "npm:react@^18.3.0": "18.3.1",
     "npm:rehype-add-classes@1.0.0": "1.0.0",
     "npm:rehype-autolink-headings@7.1.0": "7.1.0",
@@ -309,6 +311,9 @@
         "jsr:@std/internal@^1.0.3",
         "jsr:@std/path@^1.0.4"
       ]
+    },
+    "@std/yaml@1.1.2": {
+      "integrity": "de612653c036749ba2044165e316f52412b0f0698afffb7ee80b5331d6d2abae"
     },
     "@ts-morph/bootstrap@0.24.0": {
       "integrity": "a826a2ef7fa8a7c3f1042df2c034d20744d94da2ee32bf29275bcd4dffd3c060",
@@ -2184,6 +2189,11 @@
         "mime-types"
       ]
     },
+    "fsevents@2.3.2": {
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "os": ["darwin"],
+      "scripts": true
+    },
     "function-bind@1.1.2": {
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
@@ -3613,6 +3623,20 @@
     "picomatch@2.3.1": {
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
+    "playwright-core@1.62.1": {
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "bin": true
+    },
+    "playwright@1.62.1": {
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dependencies": [
+        "playwright-core"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "bin": true
+    },
     "possible-typed-array-names@1.0.0": {
       "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q=="
     },
@@ -4625,6 +4649,13 @@
         "dependencies": [
           "jsr:@std/testing@1",
           "npm:jsdom@24"
+        ]
+      },
+      "packages/playwright": {
+        "dependencies": [
+          "jsr:@std/expect@1",
+          "jsr:@std/testing@1",
+          "npm:playwright@1.62.1"
         ]
       },
       "www": {

--- a/packages/playwright/CHANGELOG.md
+++ b/packages/playwright/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Load compiled Interactors as typed Playwright proxies.

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -1,0 +1,78 @@
+# `@interactors/playwright`
+
+Load the three files produced by `interactors compile` into a Playwright page.
+The Interactor implementation stays in the browser; tests call small typed
+proxies in the Playwright process.
+
+Compile the entrypoint that exports your Interactor definitions before starting
+Playwright:
+
+```console
+$ interactors compile index.ts --outdir dist/
+```
+
+This writes `dist/agent.js`, `dist/interactors.json`, and
+`dist/interactors.d.ts`.
+
+```ts
+import type * as Definitions from "../dist/interactors.d.ts";
+import { loadInteractors } from "@interactors/playwright";
+
+let { TextField, matching } = await loadInteractors<typeof Definitions>({
+  page,
+  directory: new URL("../dist/", import.meta.url),
+});
+
+await TextField("Email").fillIn("jonas@example.com");
+await TextField(matching(/mail/i)).has({ value: "jonas@example.com" });
+```
+
+`loadInteractors()` reads and validates `interactors.json`, installs `agent.js`
+in the current document and every future navigation, and verifies that the agent
+has the same protocol version and registry hash. Each action and assertion is
+then executed with `page.evaluate()`. The agent is installed in
+the page's main frame; interacting with a child frame requires loading against a
+frame-capable adapter in the future.
+
+The generated declarations are type-only. Pass them to `loadInteractors()` as
+shown above; do not import them at runtime. `RemoteDefinitions` removes the
+definition-time builder methods and the callback-based `perform()` and
+`assert()` methods because functions cannot cross the page boundary. It also
+omits raw filter getter methods: assert filter values with `has()` or `is()` so
+the Interactor retains its convergence and diagnostic behavior.
+
+## Playwright Test fixture
+
+```ts
+import { test as base } from "@playwright/test";
+import type * as Definitions from "../dist/interactors.d.ts";
+import {
+  loadInteractors,
+  type RemoteDefinitions,
+} from "@interactors/playwright";
+
+type Fixtures = {
+  interactors: RemoteDefinitions<typeof Definitions>;
+};
+
+export const test = base.extend<Fixtures>({
+  interactors: async ({ page }, use) => {
+    await use(
+      await loadInteractors<typeof Definitions>({
+        page,
+        directory: new URL("../dist/", import.meta.url),
+      }),
+    );
+  },
+});
+```
+
+Constructor arguments, filters, matcher arguments, action arguments, and action
+results retain the types inferred from the original Interactor entrypoint.
+Command values must be JSON-shaped; regular expressions and remote matcher
+values are also supported. Action results must be values that Playwright can
+serialize back from `page.evaluate()`. The `$type` object key is reserved for
+the adapter's wire protocol and is rejected in command values.
+
+Call `loadInteractors()` once for each `Page` (including popup pages). The init
+script keeps that page's agent installed across subsequent navigations.

--- a/packages/playwright/deno.json
+++ b/packages/playwright/deno.json
@@ -1,0 +1,21 @@
+{
+  "name": "@interactors/playwright",
+  "version": "1.0.0",
+  "description": "Load compiled Interactors into Playwright",
+  "exports": "./mod.ts",
+  "tasks": {
+    "install:browser": "deno run -A npm:playwright@1.62.1 install --with-deps chromium",
+    "test": "deno test -A",
+    "test:browser": "deno task --cwd ../.. build:npm packages/playwright && deno test --no-check -A test/playwright.integration.ts"
+  },
+  "imports": {
+    "@std/expect": "jsr:@std/expect@^1.0.0",
+    "@std/testing": "jsr:@std/testing@^1.0.0",
+    "playwright": "npm:playwright@1.62.1"
+  },
+  "lint": {
+    "rules": {
+      "exclude": ["no-explicit-any", "prefer-const"]
+    }
+  }
+}

--- a/packages/playwright/mod.ts
+++ b/packages/playwright/mod.ts
@@ -1,0 +1,12 @@
+export {
+  loadInteractors,
+  type LoadInteractorsOptions,
+  type PageLike,
+} from "./src/playwright.ts";
+export type {
+  RemoteDefinitions,
+  RemoteInput,
+  RemoteInteractor,
+  RemoteMatcher,
+  RemoteMaybeMatcher,
+} from "./src/types.ts";

--- a/packages/playwright/src/client.ts
+++ b/packages/playwright/src/client.ts
@@ -1,0 +1,381 @@
+import type {
+  AgentCommand,
+  InteractorReference,
+  Registry,
+  RegistryInteractor,
+  WireValue,
+} from "./protocol.ts";
+import type { RemoteDefinitions } from "./types.ts";
+
+export interface AgentTransport {
+  run(command: AgentCommand): Promise<unknown>;
+}
+
+interface ClientRuntime {
+  readonly registry: Registry;
+  readonly transport: AgentTransport;
+}
+
+interface MatcherState {
+  readonly runtime: ClientRuntime;
+  readonly id: string;
+  readonly args: readonly unknown[];
+}
+
+interface InteractorState {
+  readonly runtime: ClientRuntime;
+  readonly path: readonly InteractorReference[];
+  readonly definition: RegistryInteractor;
+}
+
+const matcherState = Symbol("remote matcher");
+const interactorState = Symbol("remote interactor");
+
+export function createRemoteDefinitions<Definitions>(
+  registry: Registry,
+  transport: AgentTransport,
+): RemoteDefinitions<Definitions> {
+  let runtime = { registry, transport };
+  let definitions = Object.create(null) as Record<string, unknown>;
+
+  for (let definition of registry.interactors) {
+    define(
+      definitions,
+      definition.id,
+      createInteractorConstructor(runtime, definition),
+    );
+  }
+  for (let definition of registry.matchers) {
+    if (Object.hasOwn(definitions, definition.id)) {
+      throw new Error(
+        `Registry definition ${JSON.stringify(definition.id)} is duplicated`,
+      );
+    }
+    define(
+      definitions,
+      definition.id,
+      createMatcherConstructor(runtime, definition.id),
+    );
+  }
+
+  return definitions as RemoteDefinitions<Definitions>;
+}
+
+function createInteractorConstructor(
+  runtime: ClientRuntime,
+  definition: RegistryInteractor,
+): (...args: unknown[]) => unknown {
+  let constructor = (...args: unknown[]) => {
+    let reference = createReference(runtime, definition.id, args);
+    return createInteractor(runtime, [reference], definition);
+  };
+  Object.defineProperty(constructor, "name", {
+    configurable: true,
+    value: definition.id,
+  });
+  return constructor;
+}
+
+function createMatcherConstructor(
+  runtime: ClientRuntime,
+  id: string,
+): (...args: unknown[]) => unknown {
+  let constructor = (...args: unknown[]) =>
+    Object.freeze({
+      [matcherState]: { runtime, id, args } satisfies MatcherState,
+    });
+  Object.defineProperty(constructor, "name", {
+    configurable: true,
+    value: id,
+  });
+  return constructor;
+}
+
+function createInteractor(
+  runtime: ClientRuntime,
+  path: readonly InteractorReference[],
+  definition: RegistryInteractor,
+): unknown {
+  let interactor = Object.create(null) as Record<PropertyKey, unknown>;
+  let state = { runtime, path, definition } satisfies InteractorState;
+  Object.defineProperty(interactor, interactorState, { value: state });
+
+  define(interactor, "find", (child: unknown) => {
+    let childState = getInteractorState(child);
+    if (!childState || childState.runtime !== runtime) {
+      throw new TypeError(
+        "find() expects an interactor created by the same loaded registry",
+      );
+    }
+    return createInteractor(
+      runtime,
+      [...path, ...childState.path],
+      childState.definition,
+    );
+  });
+
+  for (
+    let method of [
+      "exists",
+      "absent",
+      "has",
+      "is",
+      ...definition.actions,
+    ]
+  ) {
+    define(
+      interactor,
+      method,
+      (...args: unknown[]) => invoke(state, method, args),
+    );
+  }
+
+  return interactor;
+}
+
+async function invoke(
+  state: InteractorState,
+  method: string,
+  args: readonly unknown[],
+): Promise<unknown> {
+  let command: AgentCommand = {
+    protocolVersion: state.runtime.registry.protocolVersion,
+    registryHash: state.runtime.registry.registryHash,
+    path: state.path,
+    method,
+    ...(args.length > 0
+      ? { args: args.map((arg) => encodeValue(arg, state.runtime)) }
+      : {}),
+  };
+  let result = await state.runtime.transport.run(command);
+  return unwrapResult(result);
+}
+
+function createReference(
+  runtime: ClientRuntime,
+  interactor: string,
+  args: readonly unknown[],
+): InteractorReference {
+  if (args.length > 2) {
+    throw new TypeError(
+      `Interactor ${JSON.stringify(interactor)} accepts at most two arguments`,
+    );
+  }
+  if (args.length === 0 || (args.length === 1 && args[0] === undefined)) {
+    return { interactor };
+  }
+
+  let [first, second] = args;
+  if (args.length === 1 && isFilterRecord(first)) {
+    return { interactor, filters: encodeFilters(first, runtime) };
+  }
+
+  if (!isLocator(first)) {
+    throw new TypeError(
+      `Interactor ${
+        JSON.stringify(interactor)
+      } locator must be a string, RegExp, or remote matcher`,
+    );
+  }
+
+  let reference: InteractorReference = {
+    interactor,
+    locator: encodeValue(first, runtime),
+  };
+  if (second !== undefined) {
+    if (!isFilterRecord(second)) {
+      throw new TypeError(
+        `Interactor ${
+          JSON.stringify(interactor)
+        } filters must be a plain object`,
+      );
+    }
+    reference = {
+      ...reference,
+      filters: encodeFilters(second, runtime),
+    };
+  }
+  return reference;
+}
+
+function encodeFilters(
+  filters: Record<string, unknown>,
+  runtime: ClientRuntime,
+): Record<string, WireValue> {
+  let encoded = encodeValue(filters, runtime);
+  if (
+    encoded === null || typeof encoded !== "object" ||
+    Array.isArray(encoded) || "$type" in encoded
+  ) {
+    throw new TypeError("Interactor filters must be a plain object");
+  }
+  return encoded as Record<string, WireValue>;
+}
+
+function encodeValue(
+  value: unknown,
+  runtime: ClientRuntime,
+  ancestors = new Set<object>(),
+): WireValue {
+  if (
+    value === null || typeof value === "string" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new TypeError("Interactor command numbers must be finite");
+    }
+    return value;
+  }
+  if (value instanceof RegExp) {
+    return {
+      $type: "regexp",
+      source: value.source,
+      ...(value.flags ? { flags: value.flags } : {}),
+    };
+  }
+
+  let remoteMatcher = getMatcherState(value);
+  if (remoteMatcher) {
+    if (remoteMatcher.runtime !== runtime) {
+      throw new TypeError(
+        "Matcher was created by a different loaded registry",
+      );
+    }
+    return {
+      $type: "matcher",
+      matcher: remoteMatcher.id,
+      args: remoteMatcher.args.map((arg) =>
+        encodeValue(arg, runtime, ancestors)
+      ),
+    };
+  }
+
+  if (Array.isArray(value)) {
+    return encodeObject(
+      value,
+      ancestors,
+      () => value.map((item) => encodeValue(item, runtime, ancestors)),
+    );
+  }
+  if (isPlainObject(value)) {
+    if (Object.hasOwn(value, "$type")) {
+      throw new TypeError(
+        'Interactor command objects cannot use the reserved "$type" property',
+      );
+    }
+    return encodeObject(value, ancestors, () => {
+      let encoded: Record<string, WireValue> = Object.create(null);
+      for (let [key, item] of Object.entries(value)) {
+        encoded[key] = encodeValue(item, runtime, ancestors);
+      }
+      return encoded;
+    });
+  }
+
+  throw new TypeError(
+    `Interactor commands cannot serialize ${describeValue(value)}`,
+  );
+}
+
+function encodeObject<T extends WireValue>(
+  value: object,
+  ancestors: Set<object>,
+  encode: () => T,
+): T {
+  if (ancestors.has(value)) {
+    throw new TypeError("Interactor commands cannot serialize cyclic values");
+  }
+  ancestors.add(value);
+  try {
+    return encode();
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function unwrapResult(result: unknown): unknown {
+  if (!isRecord(result) || typeof result.ok !== "boolean") {
+    throw new TypeError("Interactor agent returned an invalid result");
+  }
+  if (result.ok === true) {
+    return result.value;
+  }
+  if (
+    !isRecord(result.error) || typeof result.error.name !== "string" ||
+    typeof result.error.message !== "string" ||
+    (result.error.stack !== undefined && typeof result.error.stack !== "string")
+  ) {
+    throw new TypeError("Interactor agent returned an invalid error result");
+  }
+
+  let error = new Error(result.error.message);
+  error.name = result.error.name;
+  if (result.error.stack) {
+    error.stack = `${
+      error.stack ?? `${error.name}: ${error.message}`
+    }\n\nRemote browser stack:\n${result.error.stack}`;
+  }
+  throw error;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function getMatcherState(value: unknown): MatcherState | undefined {
+  return value !== null && typeof value === "object"
+    ? (value as { [matcherState]?: MatcherState })[matcherState]
+    : undefined;
+}
+
+function getInteractorState(value: unknown): InteractorState | undefined {
+  return value !== null && typeof value === "object"
+    ? (value as { [interactorState]?: InteractorState })[interactorState]
+    : undefined;
+}
+
+function isLocator(value: unknown): boolean {
+  return typeof value === "string" || value instanceof RegExp ||
+    getMatcherState(value) !== undefined;
+}
+
+function isFilterRecord(value: unknown): value is Record<string, unknown> {
+  return isPlainObject(value) && getMatcherState(value) === undefined;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  let prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function describeValue(value: unknown): string {
+  if (value === undefined) {
+    return "undefined";
+  }
+  if (value === null) {
+    return "null";
+  }
+  if (typeof value === "object") {
+    return Object.prototype.toString.call(value);
+  }
+  return typeof value;
+}
+
+function define(
+  target: Record<PropertyKey, unknown>,
+  name: PropertyKey,
+  value: unknown,
+): void {
+  Object.defineProperty(target, name, {
+    configurable: false,
+    enumerable: true,
+    writable: false,
+    value,
+  });
+}

--- a/packages/playwright/src/playwright.ts
+++ b/packages/playwright/src/playwright.ts
@@ -1,0 +1,322 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createRemoteDefinitions } from "./client.ts";
+import {
+  AGENT_GLOBAL,
+  AGENT_PROTOCOL_VERSION,
+  type AgentCommand,
+  type AgentResult,
+  type Registry,
+  type RegistryInteractor,
+  type RegistryMatcher,
+} from "./protocol.ts";
+import type { RemoteDefinitions } from "./types.ts";
+
+const reservedInteractorMethods = new Set([
+  "absent",
+  "apply",
+  "assert",
+  "description",
+  "exists",
+  "find",
+  "has",
+  "is",
+  "options",
+  "perform",
+  "then",
+]);
+
+export interface PageLike {
+  addInitScript(
+    script: string | { readonly content: string },
+  ): Promise<unknown>;
+  evaluate<Result, Argument = void>(
+    pageFunction:
+      | string
+      | ((argument: Argument) => Result | Promise<Result>),
+    argument?: Argument,
+  ): Promise<Awaited<Result>>;
+}
+
+export interface LoadInteractorsOptions {
+  readonly page: PageLike;
+  readonly directory: string | URL;
+}
+
+/** Load a compiled Interactor registry and connect it to a Playwright page. */
+export async function loadInteractors<Definitions = Record<never, never>>(
+  options: LoadInteractorsOptions,
+): Promise<RemoteDefinitions<Definitions>> {
+  let [registryText, agentSource] = await Promise.all([
+    readArtifact(options.directory, "interactors.json"),
+    readArtifact(options.directory, "agent.js"),
+  ]);
+  let registry = parseRegistry(registryText);
+
+  let initScript = await options.page.addInitScript({
+    content: mainFrameInitScript(agentSource),
+  });
+  try {
+    await options.page.evaluate(agentSource);
+    await verifyAgent(options.page, registry);
+  } catch (error) {
+    await disposeInitScript(initScript);
+    throw error;
+  }
+
+  return createRemoteDefinitions<Definitions>(registry, {
+    run: (command) => runCommand(options.page, command),
+  });
+}
+
+function mainFrameInitScript(agentSource: string): string {
+  return `if (globalThis.window === globalThis.top) {\n${agentSource}\n}\n`;
+}
+
+async function disposeInitScript(value: unknown): Promise<void> {
+  if (!isRecord(value) || typeof value.dispose !== "function") {
+    return;
+  }
+  try {
+    await value.dispose.call(value);
+  } catch {
+    // Preserve the installation or handshake error that caused this cleanup.
+  }
+}
+
+async function readArtifact(
+  directory: string | URL,
+  filename: string,
+): Promise<string> {
+  let path = directory instanceof URL
+    ? new URL(
+      filename,
+      directory.href.endsWith("/") ? directory : `${directory.href}/`,
+    )
+    : join(directory, filename);
+  return await readFile(path, "utf8");
+}
+
+async function verifyAgent(page: PageLike, registry: Registry): Promise<void> {
+  let identity = await page.evaluate<
+    { protocolVersion: unknown; registryHash: unknown; canRun: boolean } | null
+  >(() => {
+    let agent = Reflect.get(document.defaultView!, "__interactors__") as
+      | { protocolVersion?: unknown; registryHash?: unknown; run?: unknown }
+      | undefined;
+    return agent
+      ? {
+        protocolVersion: agent.protocolVersion,
+        registryHash: agent.registryHash,
+        canRun: typeof agent.run === "function",
+      }
+      : null;
+  });
+
+  if (!identity) {
+    throw new Error(
+      `Interactor agent was not installed as globalThis.${AGENT_GLOBAL}`,
+    );
+  }
+  if (!identity.canRun) {
+    throw new Error(
+      `Interactor agent globalThis.${AGENT_GLOBAL} does not expose run()`,
+    );
+  }
+  if (identity.protocolVersion !== registry.protocolVersion) {
+    throw new Error(
+      `Interactor protocol mismatch: registry uses ${registry.protocolVersion}, agent uses ${
+        String(identity.protocolVersion)
+      }`,
+    );
+  }
+  if (identity.registryHash !== registry.registryHash) {
+    throw new Error(
+      `Interactor registry mismatch: expected ${registry.registryHash}, agent uses ${
+        String(identity.registryHash)
+      }`,
+    );
+  }
+}
+
+async function runCommand(
+  page: PageLike,
+  command: AgentCommand,
+): Promise<unknown> {
+  return await page.evaluate<unknown, AgentCommand>(async (command) => {
+    let agent = Reflect.get(document.defaultView!, "__interactors__") as
+      | { run?: (command: AgentCommand) => Promise<AgentResult> }
+      | undefined;
+    if (!agent || typeof agent.run !== "function") {
+      return {
+        ok: false,
+        error: {
+          name: "AgentUnavailableError",
+          message: "Interactor agent is not installed in the current page",
+        },
+      };
+    }
+    return await agent.run(command);
+  }, command);
+}
+
+export function parseRegistry(source: string): Registry {
+  let value: unknown;
+  try {
+    value = JSON.parse(source);
+  } catch (error) {
+    throw new Error(
+      `Unable to parse interactors.json: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  if (!isRecord(value)) {
+    throw new Error("interactors.json must contain an object");
+  }
+  if (value.protocolVersion !== AGENT_PROTOCOL_VERSION) {
+    throw new Error(
+      `Unsupported Interactor protocol: ${String(value.protocolVersion)}`,
+    );
+  }
+  if (
+    typeof value.registryHash !== "string" ||
+    !/^sha256:[a-f0-9]{64}$/.test(value.registryHash)
+  ) {
+    throw new Error("interactors.json has an invalid registryHash");
+  }
+
+  let interactors = parseInteractors(value.interactors);
+  let matchers = parseMatchers(value.matchers);
+  validateDefinitionNames(interactors, matchers);
+
+  let content = JSON.stringify({
+    protocolVersion: AGENT_PROTOCOL_VERSION,
+    interactors,
+    matchers,
+  });
+  let expectedHash = `sha256:${
+    createHash("sha256").update(content).digest("hex")
+  }`;
+  if (value.registryHash !== expectedHash) {
+    throw new Error(
+      `interactors.json registryHash does not match its contents: expected ${expectedHash}`,
+    );
+  }
+
+  return {
+    protocolVersion: AGENT_PROTOCOL_VERSION,
+    registryHash: value.registryHash,
+    interactors,
+    matchers,
+  };
+}
+
+function parseInteractors(value: unknown): RegistryInteractor[] {
+  if (!Array.isArray(value)) {
+    throw new Error("interactors.json interactors must be an array");
+  }
+  return value.map((item, index) => {
+    if (!isRecord(item)) {
+      throw new Error(`Interactor registry entry ${index} must be an object`);
+    }
+    let id = requireString(item.id, `Interactor registry entry ${index} id`);
+    let name = requireString(
+      item.name,
+      `Interactor registry entry ${JSON.stringify(id)} name`,
+    );
+    let actions = requireStringArray(
+      item.actions,
+      `Interactor registry entry ${JSON.stringify(id)} actions`,
+    );
+    let filters = requireStringArray(
+      item.filters,
+      `Interactor registry entry ${JSON.stringify(id)} filters`,
+    );
+    let methodNames = new Set(reservedInteractorMethods);
+    for (let method of [...actions, ...filters]) {
+      if (methodNames.has(method)) {
+        throw new Error(
+          `Interactor ${JSON.stringify(id)} has duplicate or reserved method ${
+            JSON.stringify(method)
+          }`,
+        );
+      }
+      methodNames.add(method);
+    }
+    return { id, name, actions, filters };
+  });
+}
+
+function parseMatchers(value: unknown): RegistryMatcher[] {
+  if (!Array.isArray(value)) {
+    throw new Error("interactors.json matchers must be an array");
+  }
+  return value.map((item, index) => {
+    if (!isRecord(item)) {
+      throw new Error(`Matcher registry entry ${index} must be an object`);
+    }
+    let id = requireString(item.id, `Matcher registry entry ${index} id`);
+    let name = requireString(
+      item.name,
+      `Matcher registry entry ${JSON.stringify(id)} name`,
+    );
+    return { id, name };
+  });
+}
+
+function validateDefinitionNames(
+  interactors: readonly RegistryInteractor[],
+  matchers: readonly RegistryMatcher[],
+): void {
+  let names = new Set<string>();
+  for (let definition of [...interactors, ...matchers]) {
+    if (definition.id === "then") {
+      throw new Error('Registry cannot expose a definition named "then"');
+    }
+    if (names.has(definition.id)) {
+      throw new Error(
+        `Registry definition ${JSON.stringify(definition.id)} is duplicated`,
+      );
+    }
+    names.add(definition.id);
+  }
+
+  let matcherNames = new Set(matchers.map(({ id }) => id));
+  for (
+    let builtin of [
+      "and",
+      "every",
+      "including",
+      "matching",
+      "not",
+      "or",
+      "some",
+    ]
+  ) {
+    if (!matcherNames.has(builtin)) {
+      throw new Error(
+        `Registry is missing built-in matcher ${JSON.stringify(builtin)}`,
+      );
+    }
+  }
+}
+
+function requireString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function requireStringArray(value: unknown, label: string): string[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be an array`);
+  }
+  return value.map((item, index) => requireString(item, `${label}[${index}]`));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/playwright/src/protocol.ts
+++ b/packages/playwright/src/protocol.ts
@@ -1,0 +1,67 @@
+export const AGENT_GLOBAL = "__interactors__" as const;
+export const AGENT_PROTOCOL_VERSION = 1 as const;
+
+export interface RegistryInteractor {
+  readonly id: string;
+  readonly name: string;
+  readonly actions: readonly string[];
+  readonly filters: readonly string[];
+}
+
+export interface RegistryMatcher {
+  readonly id: string;
+  readonly name: string;
+}
+
+export interface Registry {
+  readonly protocolVersion: typeof AGENT_PROTOCOL_VERSION;
+  readonly registryHash: string;
+  readonly interactors: readonly RegistryInteractor[];
+  readonly matchers: readonly RegistryMatcher[];
+}
+
+export interface WireRegExp {
+  readonly $type: "regexp";
+  readonly source: string;
+  readonly flags?: string;
+}
+
+export interface WireMatcher {
+  readonly $type: "matcher";
+  readonly matcher: string;
+  readonly args: readonly WireValue[];
+}
+
+export type WireValue =
+  | null
+  | boolean
+  | number
+  | string
+  | WireRegExp
+  | WireMatcher
+  | readonly WireValue[]
+  | { readonly [key: string]: WireValue };
+
+export interface InteractorReference {
+  readonly interactor: string;
+  readonly locator?: WireValue;
+  readonly filters?: Readonly<Record<string, WireValue>>;
+}
+
+export interface AgentCommand {
+  readonly protocolVersion: number;
+  readonly registryHash: string;
+  readonly path: readonly InteractorReference[];
+  readonly method: string;
+  readonly args?: readonly WireValue[];
+}
+
+export interface AgentError {
+  readonly name: string;
+  readonly message: string;
+  readonly stack?: string;
+}
+
+export type AgentResult<T = unknown> =
+  | { readonly ok: true; readonly value?: T }
+  | { readonly ok: false; readonly error: AgentError };

--- a/packages/playwright/src/types.ts
+++ b/packages/playwright/src/types.ts
@@ -1,0 +1,141 @@
+import type {
+  InteractorConstructor,
+  Matcher,
+  MaybeMatcher,
+} from "@interactors/core";
+
+type Scalar = null | boolean | number | string;
+type AnyFunction = (...args: any[]) => any;
+type AnyInteractorConstructor = InteractorConstructor<any, any, any, any>;
+type AnyMatcherConstructor = (...args: any[]) => Matcher<any>;
+
+declare const remoteInteractorBrand: unique symbol;
+declare const remoteMatcherBrand: unique symbol;
+
+/** A matcher value whose implementation runs inside the browser agent. */
+export type RemoteMatcher<in T> = {
+  readonly [remoteMatcherBrand]: (actual: T) => void;
+};
+
+export type RemoteMaybeMatcher<T> = RemoteInput<T> | RemoteMatcher<T>;
+
+/** Values that can cross Playwright's page boundary. */
+export type RemoteInput<T> = T extends Matcher<infer Actual>
+  ? RemoteMatcher<Actual>
+  : T extends RegExp ? RegExp
+  : T extends Scalar ? T
+  : T extends undefined | bigint | symbol | AnyFunction ? never
+  : T extends readonly unknown[] ? RemoteArguments<T>
+  : T extends object ? "$type" extends keyof T ? never
+    : { [Key in keyof T]: RemoteInput<T[Key]> }
+  : never;
+
+type RemoteArguments<Args extends readonly unknown[]> = {
+  [Key in keyof Args]: RemoteInput<Args[Key]>;
+};
+
+type WidenLiteral<T> = T extends string ? string
+  : T extends number ? number
+  : T extends boolean ? boolean
+  : T;
+
+type ForbiddenInstanceKey =
+  | "perform"
+  | "assert"
+  | "options"
+  | "apply"
+  | "find"
+  | "description";
+
+type RemoteMethod<Method> = Method extends (...args: infer Args) => infer Result
+  ? Result extends PromiseLike<infer Value>
+    ? (...args: RemoteArguments<Args>) => Promise<Awaited<Value>>
+  : never
+  : never;
+
+type RemoteMethods<Instance, ExcludedKey extends PropertyKey = never> = {
+  [
+    Key in keyof Instance as Key extends ForbiddenInstanceKey | ExcludedKey
+      ? never
+      : Instance[Key] extends (...args: any[]) => PromiseLike<any> ? Key
+      : never
+  ]: RemoteMethod<Instance[Key]>;
+};
+
+type RemoteFilterKey<Constructor extends AnyInteractorConstructor> =
+  Constructor extends InteractorConstructor<any, infer Filters, any, any>
+    ? keyof Filters
+    : never;
+
+interface AnyRemoteInteractor {
+  readonly [remoteInteractorBrand]: true;
+}
+
+export type RemoteInteractor<
+  Constructor extends AnyInteractorConstructor,
+> =
+  & AnyRemoteInteractor
+  & RemoteMethods<ReturnType<Constructor>, RemoteFilterKey<Constructor>>
+  & {
+    find<Child extends AnyRemoteInteractor>(interactor: Child): Child;
+  };
+
+type RemoteInteractorConstructor<
+  Constructor extends AnyInteractorConstructor,
+> = Constructor extends InteractorConstructor<any, infer Filters, any, any> ? {
+    (filters?: RemoteInput<Filters>): RemoteInteractor<Constructor>;
+    (
+      locator: string | RegExp | RemoteMatcher<string>,
+      filters?: RemoteInput<Filters>,
+    ): RemoteInteractor<Constructor>;
+  }
+  : never;
+
+type RemoteConcreteMatcherConstructor<Constructor> = Constructor extends
+  (...args: infer Args) => Matcher<infer Actual>
+  ? (...args: RemoteArguments<Args>) => RemoteMatcher<Actual>
+  : never;
+
+type RemoteMatcherConstructor<Constructor> = Constructor extends
+  <T>(...args: MaybeMatcher<T>[]) => Matcher<T>
+  ? <T>(...args: RemoteMaybeMatcher<T>[]) => RemoteMatcher<WidenLiteral<T>>
+  : Constructor extends <T>(arg: MaybeMatcher<T>) => Matcher<Iterable<T>> ? <T>(
+      arg: RemoteMaybeMatcher<T>,
+    ) => RemoteMatcher<Iterable<WidenLiteral<T>>>
+  : Constructor extends <T>(arg: MaybeMatcher<T>) => Matcher<T>
+    ? <T>(arg: RemoteMaybeMatcher<T>) => RemoteMatcher<WidenLiteral<T>>
+  : RemoteConcreteMatcherConstructor<Constructor>;
+
+type RemoteDefinition<Definition> = Definition extends AnyInteractorConstructor
+  ? RemoteInteractorConstructor<Definition>
+  : Definition extends AnyMatcherConstructor
+    ? RemoteMatcherConstructor<Definition>
+  : never;
+
+type RemoteMappedDefinitions<Definitions> = {
+  readonly [
+    Key in keyof Definitions as Definitions[Key] extends
+      AnyInteractorConstructor ? Key
+      : Definitions[Key] extends AnyMatcherConstructor ? Key
+      : never
+  ]: RemoteDefinition<Definitions[Key]>;
+};
+
+export interface RemoteBuiltinMatchers {
+  and<T>(...args: RemoteMaybeMatcher<T>[]): RemoteMatcher<WidenLiteral<T>>;
+  or<T>(...args: RemoteMaybeMatcher<T>[]): RemoteMatcher<WidenLiteral<T>>;
+  not<T>(arg: RemoteMaybeMatcher<T>): RemoteMatcher<WidenLiteral<T>>;
+  every<T>(
+    arg: RemoteMaybeMatcher<T>,
+  ): RemoteMatcher<Iterable<WidenLiteral<T>>>;
+  some<T>(
+    arg: RemoteMaybeMatcher<T>,
+  ): RemoteMatcher<Iterable<WidenLiteral<T>>>;
+  including(substring: string): RemoteMatcher<string>;
+  matching(regexp: RegExp): RemoteMatcher<string>;
+}
+
+/** Browser-backed versions of the constructors exported by `interactors.d.ts`. */
+export type RemoteDefinitions<Definitions> =
+  & Omit<RemoteBuiltinMatchers, keyof Definitions>
+  & RemoteMappedDefinitions<Definitions>;

--- a/packages/playwright/test/client.test.ts
+++ b/packages/playwright/test/client.test.ts
@@ -1,0 +1,202 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { createRemoteDefinitions } from "../src/client.ts";
+import type { AgentCommand } from "../src/protocol.ts";
+import type * as Definitions from "./fixtures/index.ts";
+import { createTestRegistry } from "./helpers.ts";
+
+describe("remote Interactor client", () => {
+  it("turns actions into versioned agent commands", async () => {
+    let commands: AgentCommand[] = [];
+    let ui = createRemoteDefinitions<typeof Definitions>(
+      createTestRegistry(),
+      transport(commands),
+    );
+
+    await ui.TextField("Email", { disabled: false }).fillIn(
+      "jonas@example.com",
+    );
+
+    expect(commands).toEqual([{
+      protocolVersion: 1,
+      registryHash: createTestRegistry().registryHash,
+      path: [{
+        interactor: "TextField",
+        locator: "Email",
+        filters: { disabled: false },
+      }],
+      method: "fillIn",
+      args: ["jonas@example.com"],
+    }]);
+  });
+
+  it("encodes nested paths, regular expressions, and matchers", async () => {
+    let commands: AgentCommand[] = [];
+    let ui = createRemoteDefinitions<typeof Definitions>(
+      createTestRegistry(),
+      transport(commands),
+    );
+
+    await ui.Form("profile").find(
+      ui.TextField({
+        value: ui.not(ui.matching(/ready/iu)),
+      }),
+    ).has({ value: "ready" });
+
+    expect(commands).toEqual([{
+      protocolVersion: 1,
+      registryHash: createTestRegistry().registryHash,
+      path: [
+        { interactor: "Form", locator: "profile" },
+        {
+          interactor: "TextField",
+          filters: {
+            value: {
+              $type: "matcher",
+              matcher: "not",
+              args: [{
+                $type: "matcher",
+                matcher: "matching",
+                args: [{
+                  $type: "regexp",
+                  source: "ready",
+                  flags: "iu",
+                }],
+              }],
+            },
+          },
+        },
+      ],
+      method: "has",
+      args: [{ value: "ready" }],
+    }]);
+  });
+
+  it("does not expose filter getters", () => {
+    let ui = createRemoteDefinitions<typeof Definitions>(
+      createTestRegistry(),
+      transport([]),
+    );
+
+    expect(Reflect.has(ui.TextField(), "value")).toBe(false);
+    expect(Reflect.has(ui.TextField(), "disabled")).toBe(false);
+  });
+
+  it("encodes filters, custom matchers, arrays, and assertions", async () => {
+    let commands: AgentCommand[] = [];
+    let ui = createRemoteDefinitions<typeof Definitions>(
+      createTestRegistry(),
+      transport(commands),
+    );
+
+    await ui.MultiSelect({
+      values: ui.some(ui.sameLength("Neon")),
+    }).has({ values: ["Neon", "Argon"] });
+
+    expect(commands[0].path[0]).toEqual({
+      interactor: "MultiSelect",
+      filters: {
+        values: {
+          $type: "matcher",
+          matcher: "some",
+          args: [{
+            $type: "matcher",
+            matcher: "sameLength",
+            args: ["Neon"],
+          }],
+        },
+      },
+    });
+    expect(commands[0].method).toBe("has");
+    expect(commands[0].args).toEqual([{ values: ["Neon", "Argon"] }]);
+  });
+
+  it("reconstructs remote errors with their browser stack", async () => {
+    let ui = createRemoteDefinitions<typeof Definitions>(
+      createTestRegistry(),
+      transport([], {
+        ok: false,
+        error: {
+          name: "NoSuchElementError",
+          message: "text field Email was not found",
+          stack: "NoSuchElementError: browser frame",
+        },
+      }),
+    );
+
+    let caught: unknown;
+    try {
+      await ui.TextField("Email").exists();
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).name).toBe("NoSuchElementError");
+    expect((caught as Error).message).toBe("text field Email was not found");
+    expect((caught as Error).stack).toContain("Remote browser stack");
+    expect((caught as Error).stack).toContain(
+      "NoSuchElementError: browser frame",
+    );
+  });
+
+  it("rejects malformed results from the page boundary", async () => {
+    let malformed = createRemoteDefinitions<typeof Definitions>(
+      createTestRegistry(),
+      transport([], null),
+    );
+    await expect(malformed.TextField().exists()).rejects.toThrow(
+      "Interactor agent returned an invalid result",
+    );
+
+    let malformedError = createRemoteDefinitions<typeof Definitions>(
+      createTestRegistry(),
+      transport([], { ok: false, error: { name: 42, message: "broken" } }),
+    );
+    await expect(malformedError.TextField().exists()).rejects.toThrow(
+      "Interactor agent returned an invalid error result",
+    );
+  });
+
+  it("rejects values and proxies that cannot cross this client boundary", async () => {
+    let first = createRemoteDefinitions<typeof Definitions>(
+      createTestRegistry(),
+      transport([]),
+    );
+    let second = createRemoteDefinitions<typeof Definitions>(
+      createTestRegistry(),
+      transport([]),
+    );
+
+    expect(() => first.Form().find(second.TextField())).toThrow(
+      "same loaded registry",
+    );
+    expect(() => first.TextField(second.matching(/Email/))).toThrow(
+      "different loaded registry",
+    );
+
+    let cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    await expect(
+      first.TextField().has(cyclic as never),
+    ).rejects.toThrow("cyclic values");
+    await expect(
+      first.TextField().has({ $type: "regexp" } as never),
+    ).rejects.toThrow('reserved "$type" property');
+    await expect(
+      first.TextField().fillIn(Number.NaN as never),
+    ).rejects.toThrow("numbers must be finite");
+  });
+});
+
+function transport(
+  commands: AgentCommand[],
+  result: unknown = { ok: true },
+) {
+  return {
+    run(command: AgentCommand): Promise<unknown> {
+      commands.push(command);
+      return Promise.resolve(result);
+    },
+  };
+}

--- a/packages/playwright/test/fixtures/index.ts
+++ b/packages/playwright/test/fixtures/index.ts
@@ -1,0 +1,34 @@
+import { createInteractor, createMatcher } from "@interactors/core";
+
+export const TextField = createInteractor<HTMLInputElement>("text field")
+  .selector("input")
+  .locator((element) => element.id)
+  .filters({
+    disabled: (element) => element.disabled,
+    value: (element) => element.value,
+  })
+  .actions({
+    fillIn: ({ perform }, value: string) =>
+      perform((element) => {
+        element.value = value;
+        element.dispatchEvent(new Event("input", { bubbles: true }));
+      }),
+  });
+
+export const Form = createInteractor<HTMLFormElement>("form")
+  .selector("form")
+  .locator((element) => element.id);
+
+export const MultiSelect = createInteractor<HTMLSelectElement>("multi select")
+  .selector("select[multiple]")
+  .filters({
+    values: (element) =>
+      [...element.selectedOptions].map((option) => option.value),
+  });
+
+export const sameLength = createMatcher("same length", (expected: string) => ({
+  match: (actual: string) => actual.length === expected.length,
+  description: () => `same length as ${JSON.stringify(expected)}`,
+}));
+
+export const ignored = "not a remote definition";

--- a/packages/playwright/test/helpers.ts
+++ b/packages/playwright/test/helpers.ts
@@ -1,0 +1,51 @@
+import { createHash } from "node:crypto";
+import type {
+  Registry,
+  RegistryInteractor,
+  RegistryMatcher,
+} from "../src/protocol.ts";
+
+export function createTestRegistry(options: {
+  interactors?: readonly RegistryInteractor[];
+  matchers?: readonly RegistryMatcher[];
+} = {}): Registry {
+  let interactors = options.interactors ?? [
+    {
+      id: "Form",
+      name: "form",
+      actions: [],
+      filters: [],
+    },
+    {
+      id: "MultiSelect",
+      name: "multi select",
+      actions: [],
+      filters: ["values"],
+    },
+    {
+      id: "TextField",
+      name: "text field",
+      actions: ["fillIn"],
+      filters: ["disabled", "value"],
+    },
+  ];
+  let matchers = options.matchers ?? [
+    { id: "and", name: "and" },
+    { id: "every", name: "every" },
+    { id: "including", name: "including" },
+    { id: "matching", name: "matching" },
+    { id: "not", name: "not" },
+    { id: "or", name: "or" },
+    { id: "sameLength", name: "same length" },
+    { id: "some", name: "some" },
+  ];
+  let content = {
+    protocolVersion: 1 as const,
+    interactors,
+    matchers,
+  };
+  let registryHash = `sha256:${
+    createHash("sha256").update(JSON.stringify(content)).digest("hex")
+  }`;
+  return { ...content, registryHash };
+}

--- a/packages/playwright/test/playwright.integration.ts
+++ b/packages/playwright/test/playwright.integration.ts
@@ -1,0 +1,53 @@
+import { compile } from "@interactors/cli";
+import { chromium } from "playwright";
+import { loadInteractors } from "../build/npm/esm/mod.js";
+import type * as Definitions from "./fixtures/index.ts";
+
+Deno.test("compiled Interactors run through a real Playwright page", async () => {
+  let directory = await Deno.makeTempDir();
+  let browser: Awaited<ReturnType<typeof chromium.launch>> | undefined;
+
+  try {
+    browser = await chromium.launch({ headless: true });
+    await compile({
+      entrypoint: new URL("./fixtures/index.ts", import.meta.url).pathname,
+      outdir: directory,
+    });
+
+    let page = await browser.newPage();
+    await page.goto(htmlPage(`
+      <label for="Email">Email</label>
+      <form id="profile">
+        <input id="Email" />
+      </form>
+    `));
+    let ui = await loadInteractors<typeof Definitions>({ page, directory });
+
+    // This first call uses the agent evaluated into the current document.
+    await ui.TextField("Email").fillIn("jonas@example.com");
+    await ui.TextField(ui.matching(/mail/i)).has({
+      value: "jonas@example.com",
+    });
+    await ui.TextField(ui.sameLength("Other")).exists();
+    await ui.Form("profile").find(
+      ui.TextField({ disabled: false }),
+    ).has({ value: ui.including("@example.com") });
+
+    // This call uses the init script after a navigation.
+    await page.goto(htmlPage(`<input id="Name" />`));
+    await ui.TextField("Name").fillIn("after navigation");
+    await ui.TextField("Name").has({ value: "after navigation" });
+  } finally {
+    try {
+      await browser?.close();
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  }
+});
+
+function htmlPage(body: string): string {
+  return `data:text/html;charset=utf-8,${
+    encodeURIComponent(`<!doctype html><html><body>${body}</body></html>`)
+  }`;
+}

--- a/packages/playwright/test/playwright.test.ts
+++ b/packages/playwright/test/playwright.test.ts
@@ -1,0 +1,182 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { pathToFileURL } from "node:url";
+import { loadInteractors, type PageLike } from "../src/playwright.ts";
+import type { AgentCommand, AgentResult } from "../src/protocol.ts";
+import type * as Definitions from "./fixtures/index.ts";
+import { createTestRegistry } from "./helpers.ts";
+
+describe("Playwright loader", () => {
+  it("installs the agent now and for future navigations", async () => {
+    let registry = createTestRegistry();
+    let page = new FakePage({
+      protocolVersion: registry.protocolVersion,
+      registryHash: registry.registryHash,
+      canRun: true,
+    });
+
+    await withArtifacts(registry, async (directory, agentSource) => {
+      let ui = await loadInteractors<typeof Definitions>({
+        page,
+        directory: pathToFileURL(directory),
+      });
+      await ui.TextField("Email").fillIn("ready");
+
+      expect(page.initScripts).toHaveLength(1);
+      expect(page.initScripts[0]).toContain(
+        "globalThis.window === globalThis.top",
+      );
+      expect(page.initScripts[0]).toContain(agentSource);
+      expect(page.evaluatedScripts).toEqual([agentSource]);
+      expect(page.commands).toHaveLength(1);
+      expect(page.commands[0].registryHash).toBe(registry.registryHash);
+      expect(page.commands[0].method).toBe("fillIn");
+    });
+  });
+
+  it("rejects a mismatched registry and browser agent", async () => {
+    let registry = createTestRegistry();
+    let page = new FakePage({
+      protocolVersion: registry.protocolVersion,
+      registryHash: "sha256:agent-from-another-build",
+      canRun: true,
+    });
+
+    await withArtifacts(registry, async (directory) => {
+      await expect(loadInteractors({ page, directory })).rejects.toThrow(
+        "Interactor registry mismatch",
+      );
+      expect(page.disposedInitScripts).toBe(1);
+    });
+  });
+
+  it("validates the registry hash before touching the page", async () => {
+    let registry = {
+      ...createTestRegistry(),
+      registryHash: `sha256:${"0".repeat(64)}`,
+    };
+    let page = new FakePage(null);
+
+    await withArtifacts(registry, async (directory) => {
+      await expect(loadInteractors({ page, directory })).rejects.toThrow(
+        "registryHash does not match its contents",
+      );
+      expect(page.initScripts).toEqual([]);
+      expect(page.evaluatedScripts).toEqual([]);
+    });
+  });
+
+  it("rejects an installed global without an agent runner", async () => {
+    let registry = createTestRegistry();
+    let page = new FakePage({
+      protocolVersion: registry.protocolVersion,
+      registryHash: registry.registryHash,
+      canRun: false,
+    });
+
+    await withArtifacts(registry, async (directory) => {
+      await expect(loadInteractors({ page, directory })).rejects.toThrow(
+        "does not expose run()",
+      );
+      expect(page.disposedInitScripts).toBe(1);
+    });
+  });
+
+  it("requires every matcher installed by the compiled agent", async () => {
+    let registry = createTestRegistry({
+      matchers: createTestRegistry().matchers.filter(({ id }) => id !== "or"),
+    });
+    let page = new FakePage(null);
+
+    await withArtifacts(registry, async (directory) => {
+      await expect(loadInteractors({ page, directory })).rejects.toThrow(
+        'Registry is missing built-in matcher "or"',
+      );
+      expect(page.initScripts).toEqual([]);
+      expect(page.evaluatedScripts).toEqual([]);
+    });
+  });
+
+  it("rejects compiler-reserved methods before touching the page", async () => {
+    let [textField] = createTestRegistry().interactors.filter(({ id }) =>
+      id === "TextField"
+    );
+    let registry = createTestRegistry({
+      interactors: [{ ...textField, actions: ["perform"] }],
+    });
+    let page = new FakePage(null);
+
+    await withArtifacts(registry, async (directory) => {
+      await expect(loadInteractors({ page, directory })).rejects.toThrow(
+        'Interactor "TextField" has duplicate or reserved method "perform"',
+      );
+      expect(page.initScripts).toEqual([]);
+      expect(page.evaluatedScripts).toEqual([]);
+    });
+  });
+});
+
+class FakePage implements PageLike {
+  readonly initScripts: string[] = [];
+  readonly evaluatedScripts: string[] = [];
+  readonly commands: AgentCommand[] = [];
+  disposedInitScripts = 0;
+
+  constructor(
+    private readonly identity: {
+      readonly protocolVersion: unknown;
+      readonly registryHash: unknown;
+      readonly canRun: boolean;
+    } | null,
+    private readonly result: AgentResult = { ok: true },
+  ) {}
+
+  addInitScript(
+    script: string | { readonly content: string },
+  ): Promise<{ dispose: () => Promise<void> }> {
+    this.initScripts.push(typeof script === "string" ? script : script.content);
+    return Promise.resolve({
+      dispose: () => {
+        this.disposedInitScripts++;
+        return Promise.resolve();
+      },
+    });
+  }
+
+  evaluate<Result, Argument = void>(
+    pageFunction:
+      | string
+      | ((argument: Argument) => Result | Promise<Result>),
+    argument?: Argument,
+  ): Promise<Awaited<Result>> {
+    if (typeof pageFunction === "string") {
+      this.evaluatedScripts.push(pageFunction);
+      return Promise.resolve(undefined as Awaited<Result>);
+    }
+    if (argument !== undefined) {
+      this.commands.push(argument as AgentCommand);
+      return Promise.resolve(this.result as Awaited<Result>);
+    }
+    return Promise.resolve(this.identity as Awaited<Result>);
+  }
+}
+
+async function withArtifacts(
+  registry: object,
+  callback: (directory: string, agentSource: string) => Promise<void>,
+): Promise<void> {
+  let directory = await Deno.makeTempDir();
+  let agentSource = "globalThis.__interactors__ = {};\n";
+  try {
+    await Promise.all([
+      Deno.writeTextFile(
+        `${directory}/interactors.json`,
+        `${JSON.stringify(registry, null, 2)}\n`,
+      ),
+      Deno.writeTextFile(`${directory}/agent.js`, agentSource),
+    ]);
+    await callback(directory, agentSource);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+}

--- a/packages/playwright/test/types.test.ts
+++ b/packages/playwright/test/types.test.ts
@@ -1,0 +1,86 @@
+import { expect } from "@std/expect";
+import { compile } from "@interactors/cli";
+
+Deno.test("generated declarations retain the remote Playwright API types", async () => {
+  let temporary = await Deno.makeTempDir({
+    dir: new URL(".", import.meta.url).pathname,
+    prefix: ".types-test-",
+  });
+  let outdir = `${temporary}/dist`;
+  let consumer = `${temporary}/consumer.ts`;
+
+  try {
+    await compile({
+      entrypoint: new URL("./fixtures/index.ts", import.meta.url).pathname,
+      outdir,
+    });
+    await Deno.writeTextFile(
+      consumer,
+      `import type * as Definitions from "./dist/interactors.d.ts";
+import type {
+  RemoteDefinitions,
+  RemoteInput,
+  RemoteMatcher,
+} from "../../mod.ts";
+
+declare const ui: RemoteDefinitions<typeof Definitions>;
+
+const field = ui.TextField(ui.matching(/^Email$/), {
+  disabled: ui.not(true),
+  value: ui.and(ui.including("@"), ui.sameLength("a@b")),
+});
+const nested = ui.Form("signup").find(field);
+const action: Promise<void> = nested.fillIn("a@b");
+await nested.has({ value: ui.sameLength("a@b") });
+
+ui.TextField({ value: ui.matching(/ready/i), disabled: false });
+ui.MultiSelect({ values: ui.some(ui.including("Neon")) });
+
+declare const broadMatcher: RemoteMatcher<string | number>;
+const stringMatcher: RemoteMatcher<string> = broadMatcher;
+
+// @ts-expect-error fillIn accepts a string
+nested.fillIn(42);
+// @ts-expect-error value is a string filter
+ui.TextField({ value: 42 });
+// @ts-expect-error including() matches strings, not booleans
+ui.TextField({ disabled: ui.including("yes") });
+// @ts-expect-error sameLength accepts a string
+ui.sameLength(3);
+// @ts-expect-error find() takes an instantiated remote interactor
+ui.Form().find(ui.TextField);
+// @ts-expect-error builder methods are not remote methods
+ui.TextField.selector("input");
+// @ts-expect-error callback APIs cannot cross the page boundary
+field.perform(() => undefined);
+// @ts-expect-error filters must be asserted with has() or is()
+nested.value();
+// @ts-expect-error filters must be asserted with has() or is()
+nested.disabled();
+// @ts-expect-error wire-tagged objects are reserved for the adapter protocol
+const reservedWireObject: RemoteInput<{ $type: string; value: string }> = {
+  $type: "custom",
+  value: "ready",
+};
+// @ts-expect-error matchers are contravariant in the values they can accept
+const broadFromNarrow: RemoteMatcher<string | number> = ui.including("ready");
+
+void action;
+void stringMatcher;
+void reservedWireObject;
+void broadFromNarrow;
+`,
+    );
+
+    let output = await new Deno.Command(Deno.execPath(), {
+      cwd: temporary,
+      args: ["check", consumer],
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    let error = new TextDecoder().decode(output.stderr);
+    expect(output.success, error).toBe(true);
+  } finally {
+    await Deno.remove(temporary, { recursive: true });
+  }
+});

--- a/tasks/context-from-git-tag.ts
+++ b/tasks/context-from-git-tag.ts
@@ -6,32 +6,38 @@ export interface Options {
 
 export async function deriveFromGitTag([argName, gitTag]: [
   argName: string,
-  gitTag: string
+  gitTag: string,
 ]) {
-  if (argName !== "--gitTag")
+  if (argName !== "--gitTag") {
     throw new Error("First option needs to be --gitTag");
+  }
 
   const { default: covectorConfig } = await import("../.changes/config.json", {
     with: { type: "json" },
   });
-  const [pkg, _] = gitTag.replace("refs/tags/", "").split("-v");
+  const [pkg, version] = gitTag.replace("refs/tags/", "").split("-v");
+  if (!version) throw new Error(`Could not derive a version from ${gitTag}`);
   // @ts-expect-error let's undefined check
   const pkgConfig = covectorConfig.packages[pkg];
   if (!pkgConfig) throw new Error(`${pkg} not defined in .changes/config.json`);
 
   const dir = path.dirname(pkgConfig.path);
-  const outputVarDir = `working-directory=${dir}`;
+  const prerelease = version.match(/^[^-]+-([^.]+)/)?.[1];
+  const outputs = [
+    `working-directory=${dir}`,
+    `npm-tag=${prerelease ?? "latest"}`,
+  ].join("\n");
 
   if (Deno.env.has("GITHUB_OUTPUT")) {
     // type cast because TS isn't narrow despite our check
     const githubOutput = Deno.env.get("GITHUB_OUTPUT") as string;
     // write it to the output
-    await Deno.writeTextFile(githubOutput, outputVarDir, {
+    await Deno.writeTextFile(githubOutput, `${outputs}\n`, {
       append: true,
     });
   } else {
     // for local dev
-    console.log(outputVarDir);
+    console.log(outputs);
   }
 }
 


### PR DESCRIPTION
## Motivation

The compiled artifact set needs a Playwright-side consumer that is type-safe in the test process while executing the real Interactor implementation against the browser DOM.

## Approach

Add `@interactors/playwright`, which validates the compiled registry, installs the browser agent for the current document and later navigations, and exposes typed remote proxies derived from the generated declarations. Commands cross `page.evaluate()` with protocol and registry identity, supporting actions, assertions, nested Interactors, regular expressions, and built-in or custom matchers. Remote failures retain their browser error details.

Remote proxies intentionally omit raw filter getter methods. Tests assert filter values through `has()` or `is()`, preserving Interactors' convergence and diagnostics instead of extracting a value for a runner-side equality assertion.

Register the package with the release configuration and derive prerelease npm tags from Git tags so alpha releases remain off `latest`.

### Alternate Designs

Reimplementing Interactors with Playwright locators would duplicate behavior and allow the two implementations to drift. Importing browser-oriented constructors directly into the Playwright process would execute them in the wrong DOM context. The proxy and agent boundary keeps one implementation in the browser.

### Possible Drawbacks or Risks

Command inputs must be JSON-shaped values, regular expressions, or remote matchers, and returned values must be serializable by Playwright. The current transport targets the page's main frame and expects one loader call per `Page`; popup pages must be loaded separately.

### TODOs and Open Questions

Supporting child-frame-specific adapters can be considered separately.

## Learning

Playwright's init-script lifecycle applies to both navigations and child frames. The adapter guards installation to the main frame and disposes the registered script when its initial agent handshake fails.

Code passed to `page.evaluate()` cannot safely close over DNT-generated module shims. Browser callbacks instead discover their window through the document passed across the Playwright boundary.

## Screenshots

Not applicable; this is a test-runner integration API.
