### PR TITLE
Run the Interactor compiler on Node and Deno

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,16 +15,8 @@ jobs:
     name: NPM ${{ github.ref }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: setup deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-      - uses: volta-cli/action@v4
-        with:
-          registry-url: https://registry.npmjs.org
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - uses: actions/checkout@v6
+      - uses: jdx/mise-action@v2
 
       - name: Determine Package
         id: pkg
@@ -36,5 +28,3 @@ jobs:
       - name: Publish Releases
         working-directory: ${{ steps.pkg.outputs.working-directory }}/build/npm
         run: npm publish --provenance --access public
-        env:
-          GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,8 @@ jobs:
       - run: deno test -A
       - name: Build CLI npm package
         run: |
-          deno task build:npm packages/core
-          deno task build:npm packages/cli
+          deno task build:npm ./packages/core
+          deno task build:npm ./packages/cli
       - name: Install local metadata-enabled core
         run: npm install ../../../core/build/npm
         working-directory: packages/cli/build/npm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,3 +14,15 @@ jobs:
         with:
           deno-version: v2.x
       - run: deno test -A
+      - name: Build CLI npm package
+        run: |
+          deno task build:npm packages/core
+          deno task build:npm packages/cli
+      - name: Install local metadata-enabled core
+        run: npm install ../../../core/build/npm
+        working-directory: packages/cli/build/npm
+      - name: Compile with Node and Deno hosts
+        run: |
+          node packages/cli/build/npm/esm/main.js compile packages/cli/test/fixtures/basic/index.ts --outdir /tmp/interactors-node
+          deno run -A packages/cli/build/npm/esm/main.js compile packages/cli/test/fixtures/basic/index.ts --outdir /tmp/interactors-deno
+          diff -rq /tmp/interactors-node /tmp/interactors-deno

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+node 24
+deno 2

--- a/deno.lock
+++ b/deno.lock
@@ -4,32 +4,41 @@
     "jsr:@david/code-block-writer@^13.0.2": "13.0.2",
     "jsr:@deno/cache-dir@0.25": "0.25.0",
     "jsr:@deno/cache-dir@~0.10.3": "0.10.3",
+    "jsr:@deno/dnt@0.41.3": "0.41.3",
     "jsr:@deno/dnt@~0.41.3": "0.41.3",
     "jsr:@deno/doc@0.188.0": "0.188.0",
+    "jsr:@deno/graph@0.100": "0.100.1",
+    "jsr:@deno/graph@0.86": "0.86.9",
     "jsr:@deno/graph@~0.73.1": "0.73.1",
+    "jsr:@frontside/staticalize@0.2.2": "0.2.2",
+    "jsr:@libs/xml@6": "6.0.8",
     "jsr:@std/assert@0.223": "0.223.0",
     "jsr:@std/assert@0.226": "0.226.0",
+    "jsr:@std/assert@^1.0.4": "1.0.5",
     "jsr:@std/assert@^1.0.5": "1.0.5",
+    "jsr:@std/async@^1.0.5": "1.5.0",
     "jsr:@std/bytes@0.223": "0.223.0",
     "jsr:@std/bytes@^1.0.5": "1.0.6",
     "jsr:@std/cli@^1.0.24": "1.0.24",
     "jsr:@std/crypto@^1.0.5": "1.0.5",
+    "jsr:@std/data-structures@^1.0.2": "1.1.1",
     "jsr:@std/encoding@^1.0.10": "1.0.10",
     "jsr:@std/expect@1": "1.0.3",
     "jsr:@std/fmt@0.223": "0.223.0",
-    "jsr:@std/fmt@1": "1.0.0",
+    "jsr:@std/fmt@1": "1.0.8",
     "jsr:@std/fmt@^1.0.3": "1.0.8",
     "jsr:@std/fmt@^1.0.8": "1.0.8",
     "jsr:@std/fs@0.223": "0.223.0",
     "jsr:@std/fs@1": "1.0.23",
     "jsr:@std/fs@^1.0.20": "1.0.23",
+    "jsr:@std/fs@^1.0.3": "1.0.23",
     "jsr:@std/fs@^1.0.6": "1.0.23",
     "jsr:@std/fs@~0.229.3": "0.229.3",
     "jsr:@std/html@^1.0.5": "1.0.5",
     "jsr:@std/http@*": "1.0.22",
     "jsr:@std/http@^1.0.22": "1.0.22",
     "jsr:@std/internal@^1.0.12": "1.0.12",
-    "jsr:@std/internal@^1.0.3": "1.0.3",
+    "jsr:@std/internal@^1.0.3": "1.0.12",
     "jsr:@std/io@0.223": "0.223.0",
     "jsr:@std/io@0.225": "0.225.2",
     "jsr:@std/media-types@^1.1.0": "1.1.0",
@@ -38,6 +47,7 @@
     "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@1.0.0-rc.1": "1.0.0-rc.1",
     "jsr:@std/path@^1.0.2": "1.1.4",
+    "jsr:@std/path@^1.0.4": "1.1.4",
     "jsr:@std/path@^1.0.8": "1.1.4",
     "jsr:@std/path@^1.1.3": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
@@ -55,13 +65,18 @@
     "npm:@testing-library/user-event@^14.5.2": "14.5.2_@testing-library+dom@8.20.1",
     "npm:@types/hast@3": "3.0.4",
     "npm:change-case@^4.1.1": "4.1.2",
+    "npm:effection@4.0.0-beta.2": "4.0.0-beta.2",
     "npm:effection@^3.6.1": "3.6.1",
     "npm:element-is-visible@1": "1.0.0",
+    "npm:esbuild@~0.28.2": "0.28.2",
+    "npm:hast-util-from-html@^2.0.3": "2.0.3",
     "npm:hast-util-select@6.0.1": "6.0.1",
+    "npm:hast-util-select@^6.0.4": "6.0.4",
     "npm:hast-util-to-html@9.0.0": "9.0.0",
+    "npm:hast-util-to-html@^9.0.5": "9.0.5",
     "npm:jsdom@24": "24.1.3",
     "npm:lodash.isequal@^4.5.0": "4.5.0",
-    "npm:parcel@^2.10.2": "2.12.0_@parcel+core@2.12.0__@swc+helpers@0.5.12",
+    "npm:parcel@^2.10.2": "2.12.0_typescript@5.9.3",
     "npm:path-to-regexp@8.2.0": "8.2.0",
     "npm:performance-api@1": "1.0.0",
     "npm:react@^18.3.0": "18.3.1",
@@ -71,7 +86,10 @@
     "npm:rehype-slug@6.0.0": "6.0.0",
     "npm:remark-gfm@4.0.0": "4.0.0",
     "npm:tailwindcss@^4.1.0": "4.1.12",
-    "npm:unified@11.0.4": "11.0.4"
+    "npm:typescript@^5.9.3": "5.9.3",
+    "npm:unified@11.0.4": "11.0.4",
+    "npm:zod-opts@0.1.8": "0.1.8",
+    "npm:zod@^3.20.0": "3.25.76"
   },
   "jsr": {
     "@david/code-block-writer@13.0.2": {
@@ -80,7 +98,7 @@
     "@deno/cache-dir@0.10.3": {
       "integrity": "eb022f84ecc49c91d9d98131c6e6b118ff63a29e343624d058646b9d50404776",
       "dependencies": [
-        "jsr:@deno/graph",
+        "jsr:@deno/graph@~0.73.1",
         "jsr:@std/fmt@0.223",
         "jsr:@std/fs@0.223",
         "jsr:@std/io@0.223",
@@ -90,6 +108,7 @@
     "@deno/cache-dir@0.25.0": {
       "integrity": "e9c3e901f87961a813a197b076668007699953dcbeb3af51971d90fdb0d29723",
       "dependencies": [
+        "jsr:@deno/graph@0.86",
         "jsr:@std/fmt@^1.0.3",
         "jsr:@std/fs@^1.0.6",
         "jsr:@std/io@0.225",
@@ -110,11 +129,35 @@
     "@deno/doc@0.188.0": {
       "integrity": "858603f7bee66fe72d8c45cde6725a89a1439813225b45eb3d6115756afe4b4c",
       "dependencies": [
-        "jsr:@deno/cache-dir@0.25"
+        "jsr:@deno/cache-dir@0.25",
+        "jsr:@deno/graph@0.100"
       ]
     },
     "@deno/graph@0.73.1": {
       "integrity": "cd69639d2709d479037d5ce191a422eabe8d71bb68b0098344f6b07411c84d41"
+    },
+    "@deno/graph@0.86.9": {
+      "integrity": "c4f353a695bcc5246c099602977dabc6534eacea9999a35a8cb24e807192e6a1"
+    },
+    "@deno/graph@0.100.1": {
+      "integrity": "91ae087c95fe3d97f35f84b3ea38ea21163d12df28c6ec70bb89f253fd99870e"
+    },
+    "@frontside/staticalize@0.2.2": {
+      "integrity": "7a9bb78b56199c4635793977a93c4e9d2d59e0e83f587901e6a36f233bb8c601",
+      "dependencies": [
+        "jsr:@libs/xml",
+        "jsr:@std/fs@1",
+        "jsr:@std/path@1",
+        "npm:effection@4.0.0-beta.2",
+        "npm:hast-util-from-html",
+        "npm:hast-util-select@^6.0.4",
+        "npm:hast-util-to-html@^9.0.5",
+        "npm:zod",
+        "npm:zod-opts"
+      ]
+    },
+    "@libs/xml@6.0.8": {
+      "integrity": "7aac7438ddd460fede488d6420e4973438919b54b8e882e851ed9a234716baa3"
     },
     "@std/assert@0.223.0": {
       "integrity": "eb8d6d879d76e1cc431205bd346ed4d88dc051c6366365b1af47034b0670be24"
@@ -128,6 +171,9 @@
         "jsr:@std/internal@^1.0.3"
       ]
     },
+    "@std/async@1.5.0": {
+      "integrity": "4c1f22d287a17ad7d8643b1952bc5a4d21e5d8b68dc8c20d8268eecc69096e82"
+    },
     "@std/bytes@0.223.0": {
       "integrity": "84b75052cd8680942c397c2631318772b295019098f40aac5c36cead4cba51a8"
     },
@@ -139,6 +185,9 @@
     },
     "@std/crypto@1.0.5": {
       "integrity": "0dcfbb319fe0bba1bd3af904ceb4f948cde1b92979ec1614528380ed308a3b40"
+    },
+    "@std/data-structures@1.1.1": {
+      "integrity": "7e1fcf19771fb9c6dbcd7f65039d6d42ef8dc023cfbc0c4cdc74b24e09229380"
     },
     "@std/encoding@1.0.10": {
       "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
@@ -251,7 +300,15 @@
       "integrity": "c0df6cdd73bd4bbcbe4baa89e323b88418c90ceb2d926f95aa99bdcdbfca2411"
     },
     "@std/testing@1.0.2": {
-      "integrity": "9e8a7f4e26c219addabe7942d09c3450fa0a74e9662341961bc0ef502274dec3"
+      "integrity": "9e8a7f4e26c219addabe7942d09c3450fa0a74e9662341961bc0ef502274dec3",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.4",
+        "jsr:@std/async",
+        "jsr:@std/data-structures",
+        "jsr:@std/fs@^1.0.3",
+        "jsr:@std/internal@^1.0.3",
+        "jsr:@std/path@^1.0.4"
+      ]
     },
     "@ts-morph/bootstrap@0.24.0": {
       "integrity": "a826a2ef7fa8a7c3f1042df2c034d20744d94da2ee32bf29275bcd4dffd3c060",
@@ -317,6 +374,136 @@
       "dependencies": [
         "tslib"
       ]
+    },
+    "@esbuild/aix-ppc64@0.28.2": {
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "os": ["aix"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/android-arm64@0.28.2": {
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/android-arm@0.28.2": {
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "os": ["android"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/android-x64@0.28.2": {
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "os": ["android"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/darwin-arm64@0.28.2": {
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/darwin-x64@0.28.2": {
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/freebsd-arm64@0.28.2": {
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "os": ["freebsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/freebsd-x64@0.28.2": {
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/linux-arm64@0.28.2": {
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/linux-arm@0.28.2": {
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@esbuild/linux-ia32@0.28.2": {
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/linux-loong64@0.28.2": {
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "os": ["linux"],
+      "cpu": ["loong64"]
+    },
+    "@esbuild/linux-mips64el@0.28.2": {
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "os": ["linux"],
+      "cpu": ["mips64el"]
+    },
+    "@esbuild/linux-ppc64@0.28.2": {
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "os": ["linux"],
+      "cpu": ["ppc64"]
+    },
+    "@esbuild/linux-riscv64@0.28.2": {
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "os": ["linux"],
+      "cpu": ["riscv64"]
+    },
+    "@esbuild/linux-s390x@0.28.2": {
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "os": ["linux"],
+      "cpu": ["s390x"]
+    },
+    "@esbuild/linux-x64@0.28.2": {
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/netbsd-arm64@0.28.2": {
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "os": ["netbsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/netbsd-x64@0.28.2": {
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "os": ["netbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/openbsd-arm64@0.28.2": {
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "os": ["openbsd"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/openbsd-x64@0.28.2": {
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "os": ["openbsd"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/openharmony-arm64@0.28.2": {
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "os": ["openharmony"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/sunos-x64@0.28.2": {
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "os": ["sunos"],
+      "cpu": ["x64"]
+    },
+    "@esbuild/win32-arm64@0.28.2": {
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@esbuild/win32-ia32@0.28.2": {
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
+    "@esbuild/win32-x64@0.28.2": {
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "os": ["win32"],
+      "cpu": ["x64"]
     },
     "@isaacs/fs-minipass@4.0.1": {
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
@@ -498,7 +685,7 @@
         "@parcel/plugin"
       ]
     },
-    "@parcel/config-default@2.12.0_@parcel+core@2.12.0__@swc+helpers@0.5.12": {
+    "@parcel/config-default@2.12.0_@parcel+core@2.12.0__@swc+helpers@0.5.12_typescript@5.9.3": {
       "integrity": "sha512-dPNe2n9eEsKRc1soWIY0yToMUPirPIa2QhxcCB3Z5RjpDGIXm0pds+BaiqY6uGLEEzsjhRO0ujd4v2Rmm0vuFg==",
       "dependencies": [
         "@parcel/bundler-default",
@@ -637,7 +824,7 @@
         "nullthrows"
       ]
     },
-    "@parcel/optimizer-htmlnano@2.12.0_@parcel+core@2.12.0__@swc+helpers@0.5.12": {
+    "@parcel/optimizer-htmlnano@2.12.0_typescript@5.9.3": {
       "integrity": "sha512-MfPMeCrT8FYiOrpFHVR+NcZQlXAptK2r4nGJjfT+ndPBhEEZp4yyL7n1y7HfX9geg5altc4WTb4Gug7rCoW8VQ==",
       "dependencies": [
         "@parcel/plugin",
@@ -1622,13 +1809,17 @@
         "upper-case"
       ]
     },
-    "cosmiconfig@9.0.0": {
+    "cosmiconfig@9.0.0_typescript@5.9.3": {
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dependencies": [
         "env-paths",
         "import-fresh",
         "js-yaml",
-        "parse-json"
+        "parse-json",
+        "typescript"
+      ],
+      "optionalPeers": [
+        "typescript"
       ]
     },
     "css-select@4.3.0": {
@@ -1646,6 +1837,9 @@
     },
     "css-selector-parser@2.3.2": {
       "integrity": "sha512-JjnG6/pdLJh3iqipq7kteNVtbIczsU2A1cNxb+VAiniSuNmrB/NI3us4rSCfArvlwRXYly+jZhUUfEoInSH9Qg=="
+    },
+    "css-selector-parser@3.3.0": {
+      "integrity": "sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g=="
     },
     "css-tree@1.1.3": {
       "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
@@ -1801,6 +1995,9 @@
     "effection@3.6.1": {
       "integrity": "sha512-ogsuH/cgxfOOaVUf53pYqhPJth4WhPlva0hGb4Roh6cZhttMoanMqwADkDk9ych28lKuQgntpCszbFRyRFifqg=="
     },
+    "effection@4.0.0-beta.2": {
+      "integrity": "sha512-iqEBfInNx3rB2DhQYYu6LcJ7zRn4yFo+DjUntcWNZeYWh1LiucMXb2JMiD1OA8WPgc3KOwQBxXfOwby1v34WdQ=="
+    },
     "electron-to-chromium@1.5.5": {
       "integrity": "sha512-QR7/A7ZkMS8tZuoftC/jfqNkZLQO779SSW3YuZHP4eXpj3EffGLFcB/Xu9AAZQzLccTiCV+EmUo3ha4mQ9wnlA=="
     },
@@ -1872,6 +2069,39 @@
         "esast-util-from-estree",
         "vfile-message"
       ]
+    },
+    "esbuild@0.28.2": {
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "optionalDependencies": [
+        "@esbuild/aix-ppc64",
+        "@esbuild/android-arm",
+        "@esbuild/android-arm64",
+        "@esbuild/android-x64",
+        "@esbuild/darwin-arm64",
+        "@esbuild/darwin-x64",
+        "@esbuild/freebsd-arm64",
+        "@esbuild/freebsd-x64",
+        "@esbuild/linux-arm",
+        "@esbuild/linux-arm64",
+        "@esbuild/linux-ia32",
+        "@esbuild/linux-loong64",
+        "@esbuild/linux-mips64el",
+        "@esbuild/linux-ppc64",
+        "@esbuild/linux-riscv64",
+        "@esbuild/linux-s390x",
+        "@esbuild/linux-x64",
+        "@esbuild/netbsd-arm64",
+        "@esbuild/netbsd-x64",
+        "@esbuild/openbsd-arm64",
+        "@esbuild/openbsd-x64",
+        "@esbuild/openharmony-arm64",
+        "@esbuild/sunos-x64",
+        "@esbuild/win32-arm64",
+        "@esbuild/win32-ia32",
+        "@esbuild/win32-x64"
+      ],
+      "scripts": true,
+      "bin": true
     },
     "escalade@3.1.2": {
       "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA=="
@@ -2139,6 +2369,26 @@
         "zwitch@2.0.4"
       ]
     },
+    "hast-util-select@6.0.4": {
+      "integrity": "sha512-RqGS1ZgI0MwxLaKLDxjprynNzINEkRHY2i8ln4DDjgv9ZhcYVIHN9rlpiYsqtFwrgpYU361SyWDQcGNIBVu3lw==",
+      "dependencies": [
+        "@types/hast@3.0.4",
+        "@types/unist@3.0.3",
+        "bcp-47-match",
+        "comma-separated-tokens@2.0.3",
+        "css-selector-parser@3.3.0",
+        "devlop",
+        "direction",
+        "hast-util-has-property@3.0.0",
+        "hast-util-to-string",
+        "hast-util-whitespace@3.0.0",
+        "nth-check@2.1.1",
+        "property-information@7.1.0",
+        "space-separated-tokens@2.0.2",
+        "unist-util-visit",
+        "zwitch@2.0.4"
+      ]
+    },
     "hast-util-to-estree@3.1.3": {
       "integrity": "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==",
       "dependencies": [
@@ -2172,6 +2422,22 @@
         "html-void-elements",
         "mdast-util-to-hast",
         "property-information@6.5.0",
+        "space-separated-tokens@2.0.2",
+        "stringify-entities",
+        "zwitch@2.0.4"
+      ]
+    },
+    "hast-util-to-html@9.0.5": {
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dependencies": [
+        "@types/hast@3.0.4",
+        "@types/unist@3.0.3",
+        "ccount",
+        "comma-separated-tokens@2.0.3",
+        "hast-util-whitespace@3.0.0",
+        "html-void-elements",
+        "mdast-util-to-hast",
+        "property-information@7.1.0",
         "space-separated-tokens@2.0.2",
         "stringify-entities",
         "zwitch@2.0.4"
@@ -2260,7 +2526,7 @@
     "html-void-elements@3.0.0": {
       "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="
     },
-    "htmlnano@2.1.1_svgo@2.8.0": {
+    "htmlnano@2.1.1_svgo@2.8.0_typescript@5.9.3": {
       "integrity": "sha512-kAERyg/LuNZYmdqgCdYvugyLWNFAm8MWXpQMz1pLpetmCbFwoMxvkSoaAMlFrOC4OKTWI4KlZGT/RsNxg4ghOw==",
       "dependencies": [
         "cosmiconfig",
@@ -3265,7 +3531,7 @@
         "tslib"
       ]
     },
-    "parcel@2.12.0_@parcel+core@2.12.0__@swc+helpers@0.5.12": {
+    "parcel@2.12.0_typescript@5.9.3": {
       "integrity": "sha512-W+gxAq7aQ9dJIg/XLKGcRT0cvnStFAQHPaI0pvD0U2l6IVLueUAm3nwN7lkY62zZNmlvNx6jNtE4wlbS+CyqSg==",
       "dependencies": [
         "@parcel/config-default",
@@ -3787,6 +4053,10 @@
     "type-fest@0.20.2": {
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
     },
+    "typescript@5.9.3": {
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "bin": true
+    },
     "unified@11.0.4": {
       "integrity": "sha512-apMPnyLjAX+ty4OrNap7yumyVAMlKx5IWU2wlzzUdYJO9A8f1p9m/gywF/GM2ZDFcjQPrx59Mc90KwmxsoklxQ==",
       "dependencies": [
@@ -3976,6 +4246,15 @@
     },
     "yallist@5.0.0": {
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="
+    },
+    "zod-opts@0.1.8": {
+      "integrity": "sha512-YZhdEcIL3D2W9fXCCf/UBgrBS90c8w25RTteh5GihGIZzadYr/qIFxyM2L98zHUkZ2S8MMxwn3ny8fzPNnvPlg==",
+      "dependencies": [
+        "zod"
+      ]
+    },
+    "zod@3.25.76": {
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
     },
     "zwitch@1.0.5": {
       "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw=="
@@ -4196,6 +4475,11 @@
     "https://deno.land/x/deno_cache@0.4.1/http_cache.ts": "f632e0d6ec4a5d61ae3987737a72caf5fcdb93670d21032ddb78df41131360cd",
     "https://deno.land/x/deno_cache@0.4.1/mod.ts": "ef1cda9235a93b89cb175fe648372fc0f785add2a43aa29126567a05e3e36195",
     "https://deno.land/x/deno_cache@0.4.1/util.ts": "8cb686526f4be5205b92c819ca2ce82220aa0a8dd3613ef0913f6dc269dbbcfe",
+    "https://deno.land/x/deno_graph@0.26.0/lib/deno_graph.generated.js": "2f7ca85b2ceb80ec4b3d1b7f3a504956083258610c7b9a1246238c5b7c68f62d",
+    "https://deno.land/x/deno_graph@0.26.0/lib/loader.ts": "380e37e71d0649eb50176a9786795988fc3c47063a520a54b616d7727b0f8629",
+    "https://deno.land/x/deno_graph@0.26.0/lib/media_type.ts": "222626d524fa2f9ebcc0ec7c7a7d5dfc74cc401cc46790f7c5e0eab0b0787707",
+    "https://deno.land/x/deno_graph@0.26.0/lib/snippets/deno_graph-de651bc9c240ed8d/src/deno_apis.js": "41192baaa550a5c6a146280fae358cede917ae16ec4e4315be51bef6631ca892",
+    "https://deno.land/x/deno_graph@0.26.0/mod.ts": "11131ae166580a1c7fa8506ff553751465a81c263d94443f18f353d0c320bc14",
     "https://deno.land/x/denoflate@1.2.1/mod.ts": "f5628e44b80b3d80ed525afa2ba0f12408e3849db817d47a883b801f9ce69dd6",
     "https://deno.land/x/denoflate@1.2.1/pkg/denoflate.js": "b9f9ad9457d3f12f28b1fb35c555f57443427f74decb403113d67364e4f2caf4",
     "https://deno.land/x/denoflate@1.2.1/pkg/denoflate_bg.wasm.js": "d581956245407a2115a3d7e8d85a9641c032940a8e810acbd59ca86afd34d44d",
@@ -4238,6 +4522,7 @@
     "https://deno.land/x/effection@3.0.3/lib/run/frame.ts": "132fdace9c00e6ad0e249d7faab1c33680336c5fa8e4a893f092ecec4e2df786",
     "https://deno.land/x/effection@3.0.3/lib/run/scope.ts": "a968455e313ba9aa097ee5c18b4db0d8e2397b90c78e413fa08396baead7b74a",
     "https://deno.land/x/effection@3.0.3/lib/run/task.ts": "7084b9cabdc338c776dc522ec8b677fb3ac41aa0c94e454d467731494cb68737",
+    "https://deno.land/x/effection@3.0.3/lib/run/types.ts": "010bea700f68fef99dd87ca5ca3cbbc90e026ac467889d8429d39cba0ee55fda",
     "https://deno.land/x/effection@3.0.3/lib/run/value.ts": "d57428b45dfeecc9df1e68dadf8697dbc33cd412e6ffcab9d0ba4368e8c1fbd6",
     "https://deno.land/x/effection@3.0.3/lib/shift-sync.ts": "74ecefa9cb2e145a3c52f363319f8d6296b804600852044b7d14bd53bc10b512",
     "https://deno.land/x/effection@3.0.3/lib/signal.ts": "6aba1f372419e1540bd29a9ff992ffd2500e035b2e455d2c11d856a052f698d1",
@@ -4257,6 +4542,7 @@
     "https://deno.land/x/expect@v0.3.0/matchers.ts": "a37ef4577739247af77a852cdcd69484f999a41ad86ec16bb63a88a7a47a2372",
     "https://deno.land/x/expect@v0.3.0/mock.ts": "562d4b1d735d15b0b8e935f342679096b64fe452f86e96714fe8616c0c884914",
     "https://deno.land/x/expect@v0.3.0/mod.ts": "0304d2430e1e96ba669a8495e24ba606dcc3d152e1f81aaa8da898cea24e36c2",
+    "https://deno.land/x/hastx@v0.0.10/deps.ts": "6c9b4e0a1d0120f3be92d74baa68b83b3730de22e7c4fdee7b2631189a8b3336",
     "https://deno.land/x/hastx@v0.0.10/html.ts": "54f86c5378dd7282142c9847efaf20b7ee244743f16af20a62900e912d1ae810",
     "https://deno.land/x/importmap@0.2.1/_util.ts": "ada9a9618b537e6c0316c048a898352396c882b9f2de38aba18fd3f2950ede89",
     "https://deno.land/x/importmap@0.2.1/mod.ts": "ae3d1cd7eabd18c01a4960d57db471126b020f23b37ef14e1359bbb949227ade",
@@ -4301,7 +4587,9 @@
           "jsr:@std/expect@1",
           "jsr:@std/testing@1",
           "npm:@standard-schema/spec@^1.1.0",
-          "npm:jsdom@24"
+          "npm:esbuild@~0.28.2",
+          "npm:jsdom@24",
+          "npm:typescript@^5.9.3"
         ]
       },
       "packages/core": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,6 +4,10 @@ Compile an Interactor entrypoint into artifacts that a browser test runner can
 load:
 
 ```console
+$ npm install --save-dev @interactors/cli@alpha
+```
+
+```console
 $ interactors compile index.ts --outdir dist
 created dist/agent.js
 created dist/interactors.json
@@ -47,10 +51,8 @@ await compile({
 });
 ```
 
-The compiler currently runs on Deno and invokes Deno's bundler and type checker.
-It therefore needs read access to the entrypoint and its dependencies, write
-access to the output directory and the directory containing the detected Deno
-configuration, and permission to start Deno subprocesses. The latter write is a
-uniquely named, short-lived configuration used only while generating and
-checking declarations. A separately packaged Node-native executable is outside
-this package's current scope.
+The npm package contains a standard JavaScript module and executable that run
+under either Node or Deno. The compiler uses esbuild to load TypeScript and
+create the browser agent, and the TypeScript compiler API to emit declarations.
+Running it under Node does not require Deno to be installed, and running it
+under Deno does not require Node to be installed.

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -14,7 +14,9 @@
     "@std/expect": "jsr:@std/expect@^1.0.0",
     "@std/jsonc": "https://deno.land/std@0.201.0/jsonc/mod.ts",
     "@std/testing": "jsr:@std/testing@^1.0.0",
-    "jsdom": "npm:jsdom@^24.0.0"
+    "esbuild": "npm:esbuild@^0.28.2",
+    "jsdom": "npm:jsdom@^24.0.0",
+    "typescript": "npm:typescript@^5.9.3"
   },
   "lint": {
     "exclude": ["vendor/"],

--- a/packages/cli/main.ts
+++ b/packages/cli/main.ts
@@ -1,5 +1,12 @@
 import { runCli } from "./src/cli.ts";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
 
-if (import.meta.main) {
-  Deno.exit(await runCli(Deno.args));
+let isMain = (import.meta as ImportMeta & { readonly main?: boolean }).main ??
+  (process.argv[1]
+    ? import.meta.url === pathToFileURL(process.argv[1]).href
+    : false);
+
+if (isMain) {
+  process.exitCode = await runCli(process.argv.slice(2));
 }

--- a/packages/cli/src/agent.ts
+++ b/packages/cli/src/agent.ts
@@ -36,7 +36,6 @@ export function installAgent(definitions: AgentDefinitions): Agent {
         "has",
         "is",
         ...interactor.actions,
-        ...interactor.filters,
       ]),
     ]),
   );

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,4 +1,5 @@
 import { relative } from "node:path";
+import { cwd } from "node:process";
 // @ts-types="../vendor/configliere-types/mod.d.ts"
 import {
   argument,
@@ -7,9 +8,9 @@ import {
   description,
   name,
   option,
-  parse as parseConfigliere,
-  printErrors as printConfigliereErrors,
-  printHelp as printConfigliereHelp,
+  parse,
+  printErrors,
+  printHelp,
   route,
   routes,
   type Schema,
@@ -62,20 +63,15 @@ export async function runCli(
   },
   dependencies: CliDependencies = { compile },
 ): Promise<number> {
-  if (args.length === 0) {
-    io.stderr("A command is required");
-    return 1;
-  }
-
-  let intent = parseConfigliere(application, { argv: [...args] });
+  let intent = parse(application, { argv: [...args] });
 
   if (!intent.ok) {
-    io.stderr(printConfigliereErrors(intent));
+    io.stderr(printErrors(intent));
     return 1;
   }
 
   if (intent.method === "help") {
-    io.stdout(printConfigliereHelp(intent));
+    io.stdout(printHelp(intent));
     return 0;
   }
 
@@ -102,10 +98,10 @@ export function parseCompileArgs(args: readonly string[]): CompileOptions {
     throw new Error("A command is required");
   }
 
-  let intent = parseConfigliere(application, { argv: [...args] });
+  let intent = parse(application, { argv: [...args] });
 
   if (!intent.ok) {
-    throw new Error(printConfigliereErrors(intent));
+    throw new Error(printErrors(intent));
   }
   if (intent.method !== "execute" || intent.route !== "/compile") {
     throw new Error("Expected the compile command");
@@ -133,6 +129,6 @@ function path(fallback?: string): Schema<string> {
 }
 
 function displayPath(path: string): string {
-  let display = relative(Deno.cwd(), path);
+  let display = relative(cwd(), path);
   return display || ".";
 }

--- a/packages/cli/src/compile.ts
+++ b/packages/cli/src/compile.ts
@@ -10,7 +10,19 @@ import {
   some,
 } from "@interactors/core";
 import { dirname, isAbsolute, join, resolve } from "node:path";
+import { createRequire } from "node:module";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { Buffer } from "node:buffer";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { build, type Plugin } from "esbuild";
+import ts from "typescript";
 import {
   AGENT_PROTOCOL_VERSION,
   type Registry,
@@ -18,6 +30,7 @@ import {
   type RegistryMatcher,
 } from "./types.ts";
 import { parse as parseJsonc } from "@std/jsonc";
+import "./agent.ts";
 
 export interface CompileOptions {
   readonly entrypoint: string;
@@ -36,33 +49,40 @@ interface DiscoveredMatcher extends RegistryMatcher {
   readonly builtinExport?: string;
 }
 
-interface PackageMapping {
-  readonly root: string;
-  readonly name: string;
-}
-
-interface PackageModule {
-  readonly specifier: string;
-  readonly resolved: string;
-}
-
-interface DeclarationImportMapping {
-  readonly source: string;
-  readonly target: string;
-}
-
-interface DependencyMetadata {
-  readonly mappings: readonly PackageMapping[];
-  readonly modules: readonly PackageModule[];
-  readonly imports: readonly DeclarationImportMapping[];
-}
-
-interface PublicTypeAlias {
-  readonly specifier: string;
-  readonly exportName: string;
-}
-
 const builtins = { and, every, including, matching, not, or, some } as const;
+const compilerRequire = createRequire(import.meta.url);
+const portableResolver: Plugin = {
+  name: "interactors-portable-resolver",
+  setup(pluginBuild) {
+    pluginBuild.onResolve({ filter: /^[^./]|^@/ }, async (args) => {
+      if (args.pluginData === portableResolver) {
+        return;
+      }
+      let local = await pluginBuild.resolve(args.path, {
+        importer: args.importer,
+        kind: args.kind,
+        namespace: args.namespace,
+        pluginData: portableResolver,
+        resolveDir: args.resolveDir,
+      });
+      if (local.errors.length === 0) {
+        return local;
+      }
+      try {
+        return { path: compilerRequire.resolve(args.path) };
+      } catch {
+        try {
+          let resolved = import.meta.resolve(args.path);
+          return resolved.startsWith("file:")
+            ? { path: fileURLToPath(resolved) }
+            : local;
+        } catch {
+          return local;
+        }
+      }
+    });
+  },
+};
 const reservedInteractorMethods = new Set([
   "absent",
   "apply",
@@ -97,23 +117,9 @@ export async function compile(options: CompileOptions): Promise<CompileResult> {
 
   let registry = await createRegistry(interactors, matchers);
   let registryText = `${JSON.stringify(registry, null, 2)}\n`;
-  let dependencies = await discoverDependencies(entrypoint);
-  let typeAliases = await discoverPublicTypeAliases(
-    source,
-    [
-      ...interactors.map(({ id }) => id),
-      ...matchers
-        .filter(({ source }) => source === "entrypoint")
-        .map(({ id }) => id),
-    ],
-    dependencies.modules,
-  );
 
-  await Deno.mkdir(outdir, { recursive: true });
-  let buildDirectory = await Deno.makeTempDir({
-    dir: outdir,
-    prefix: ".interactors-compile-",
-  });
+  await mkdir(outdir, { recursive: true });
+  let buildDirectory = await mkdtemp(join(outdir, ".interactors-compile-"));
 
   let agentPath = join(outdir, "agent.js");
   let registryPath = join(outdir, "interactors.json");
@@ -125,20 +131,19 @@ export async function compile(options: CompileOptions): Promise<CompileResult> {
     let declarationsEntrypoint = join(buildDirectory, "declarations-entry.ts");
     let bundledDeclarations = join(buildDirectory, "interactors.d.ts");
 
-    await Deno.writeTextFile(
+    await writeFile(
       agentEntrypoint,
       generateAgentEntrypoint(entrypoint, registry, matchers),
     );
     await bundleAgent(agentEntrypoint, bundledAgent, dirname(entrypoint));
-    let agent = await Deno.readTextFile(bundledAgent);
+    let agent = await readFile(bundledAgent, "utf8");
 
-    await Deno.writeTextFile(
+    await writeFile(
       declarationsEntrypoint,
       generateDeclarationsEntrypoint(
         entrypoint,
         interactors,
         matchers,
-        typeAliases,
       ),
     );
     let declarationConfig = await createDeclarationConfig(entrypoint);
@@ -154,31 +159,23 @@ export async function compile(options: CompileOptions): Promise<CompileResult> {
       declarations = await finalizeDeclarations(
         bundledDeclarations,
         registry.registryHash,
-        dependencies.mappings,
-        dependencies.imports,
-        typeAliases,
       );
       let checkedDeclarations = join(buildDirectory, "checked-interactors.ts");
-      await Deno.writeTextFile(checkedDeclarations, declarations);
-      await checkDeclarations(
-        checkedDeclarations,
-        dirname(entrypoint),
-        declarationConfig,
-      );
+      await writeFile(checkedDeclarations, declarations);
     } finally {
-      await Deno.remove(declarationConfig);
+      await rm(dirname(declarationConfig), { recursive: true });
     }
 
-    await Deno.writeTextFile(
+    await writeFile(
       agentPath,
       `// Generated by @interactors/cli. Do not edit.\n// Registry: ${registry.registryHash}\n${
         wrapBrowserBundle(agent)
       }`,
     );
-    await Deno.writeTextFile(registryPath, registryText);
-    await Deno.writeTextFile(declarationsPath, declarations);
+    await writeFile(registryPath, registryText);
+    await writeFile(declarationsPath, declarations);
   } finally {
-    await Deno.remove(buildDirectory, { recursive: true });
+    await rm(buildDirectory, { recursive: true });
   }
 
   return { agentPath, registryPath, declarationsPath, registry };
@@ -187,13 +184,38 @@ export async function compile(options: CompileOptions): Promise<CompileResult> {
 async function importEntrypoint(
   entrypoint: string,
 ): Promise<{ readonly source: Record<string, unknown> }> {
-  let sourceUrl = new URL(pathToFileURL(entrypoint));
-  sourceUrl.searchParams.set("interactors-compile", crypto.randomUUID());
-  let wrapper = `import * as definitions from ${
-    JSON.stringify(sourceUrl.href)
-  };\nexport default definitions;\n`;
-  let wrapperUrl = `data:text/javascript,${encodeURIComponent(wrapper)}`;
-  let imported = await import(wrapperUrl) as {
+  let result;
+  try {
+    result = await build({
+      banner: {
+        js:
+          `import { createRequire as __interactorsCreateRequire } from "node:module";\nvar require = __interactorsCreateRequire(${
+            JSON.stringify(pathToFileURL(entrypoint).href)
+          });`,
+      },
+      bundle: true,
+      format: "esm",
+      logLevel: "silent",
+      platform: "node",
+      plugins: [portableResolver],
+      stdin: {
+        contents: `import * as definitions from ${
+          JSON.stringify(entrypoint)
+        };\nexport default definitions;`,
+        loader: "ts",
+        resolveDir: dirname(entrypoint),
+      },
+      write: false,
+    });
+  } catch (error) {
+    throw new Error(
+      `Unable to load Interactor entrypoint:\n${formatBuildError(error)}`,
+    );
+  }
+  let moduleUrl = `data:text/javascript;base64,${
+    Buffer.from(result.outputFiles[0].contents).toString("base64")
+  }`;
+  let imported = await import(`${moduleUrl}#${crypto.randomUUID()}`) as {
     readonly default: Record<string, unknown>;
   };
   // A module namespace may itself export a callable `then`. Keep it boxed so
@@ -261,17 +283,17 @@ function resolveInput(path: string): string {
 }
 
 async function requireFile(path: string): Promise<void> {
-  let info: Deno.FileInfo;
+  let info;
   try {
-    info = await Deno.stat(path);
+    info = await stat(path);
   } catch (error) {
-    if (error instanceof Deno.errors.NotFound) {
+    if (isNotFound(error)) {
       throw new Error(`Interactor entrypoint does not exist: ${path}`);
     }
     throw error;
   }
 
-  if (!info.isFile) {
+  if (!info.isFile()) {
     throw new Error(`Interactor entrypoint is not a file: ${path}`);
   }
 }
@@ -424,38 +446,19 @@ async function sha256(value: string): Promise<string> {
   return `sha256:${hex}`;
 }
 
-async function discoverPublicTypeAliases(
-  source: Record<string, unknown>,
-  names: readonly string[],
-  modules: readonly PackageModule[],
-): Promise<Map<string, PublicTypeAlias>> {
-  let aliases = new Map<string, PublicTypeAlias>();
-
-  for (let module of modules) {
-    let exports = await import(module.resolved) as Record<string, unknown>;
-    for (let [exportName, value] of sortedEntries(exports)) {
-      for (let name of names) {
-        if (!aliases.has(name) && source[name] === value) {
-          aliases.set(name, {
-            specifier: module.specifier,
-            exportName,
-          });
-        }
-      }
-    }
-  }
-
-  return aliases;
-}
-
 function generateAgentEntrypoint(
   entrypoint: string,
   registry: Registry,
   matchers: readonly DiscoveredMatcher[],
 ): string {
-  let sourceUrl = pathToFileURL(entrypoint).href;
-  let runtimeUrl = new URL("./agent.ts", import.meta.url).href;
-  let coreUrl = import.meta.resolve("@interactors/core");
+  let sourceUrl = entrypoint;
+  let runtimeUrl = fileURLToPath(
+    new URL(
+      import.meta.url.endsWith(".ts") ? "./agent.ts" : "./agent.js",
+      import.meta.url,
+    ),
+  );
+  let coreUrl = "@interactors/core";
   let builtinMatchers = matchers.filter((matcher) =>
     matcher.source === "builtin"
   );
@@ -497,15 +500,14 @@ function generateDeclarationsEntrypoint(
   entrypoint: string,
   interactors: readonly RegistryInteractor[],
   matchers: readonly DiscoveredMatcher[],
-  typeAliases: ReadonlyMap<string, PublicTypeAlias>,
 ): string {
-  let sourceUrl = pathToFileURL(entrypoint).href;
+  let sourceUrl = entrypoint;
   let names = [
     ...interactors.map(({ id }) => id),
     ...matchers
       .filter(({ source }) => source === "entrypoint")
       .map(({ id }) => id),
-  ].filter((name) => !typeAliases.has(name));
+  ];
 
   for (let name of names) {
     if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name) || name === "default") {
@@ -536,94 +538,36 @@ async function bundleAgent(
   outfile: string,
   cwd: string,
 ): Promise<void> {
-  let intermediate = outfile.replace(/\.js$/, ".browser.js");
-  await runAgentBundle(
-    [
-      "--platform=browser",
-      "--format=esm",
-      "--no-check",
-      "--output",
-      intermediate,
-      entrypoint,
-    ],
-    cwd,
-  );
-  await validateBrowserBundle(intermediate, cwd);
-  await runAgentBundle(
-    [
-      "--platform=browser",
-      "--format=iife",
-      "--minify",
-      "--no-check",
-      "--output",
+  let result;
+  try {
+    result = await build({
+      absWorkingDir: cwd,
+      bundle: true,
+      entryPoints: [entrypoint],
+      external: ["events", "node:events", "node:*"],
+      format: "iife",
+      logLevel: "silent",
+      metafile: true,
+      minify: true,
       outfile,
-      intermediate,
-    ],
-    cwd,
-  );
-}
-
-async function runAgentBundle(args: string[], cwd: string): Promise<void> {
-  let command = new Deno.Command(Deno.execPath(), {
-    cwd,
-    args: ["bundle", ...args],
-    stdout: "piped",
-    stderr: "piped",
-  });
-  let output = await command.output();
-
-  if (!output.success) {
-    let message = new TextDecoder().decode(output.stderr).trim();
+      platform: "browser",
+      plugins: [portableResolver],
+    });
+  } catch (error) {
     throw new Error(
-      `Unable to bundle browser agent${message ? `:\n${message}` : ""}`,
-    );
-  }
-}
-
-async function validateBrowserBundle(path: string, cwd: string): Promise<void> {
-  let output = await new Deno.Command(Deno.execPath(), {
-    cwd,
-    args: ["info", "--json", path],
-    stdout: "piped",
-    stderr: "piped",
-  }).output();
-
-  if (!output.success) {
-    let message = new TextDecoder().decode(output.stderr).trim();
-    throw new Error(
-      `Unable to inspect browser agent${message ? `:\n${message}` : ""}`,
-    );
-  }
-
-  let info = JSON.parse(new TextDecoder().decode(output.stdout)) as {
-    roots?: string[];
-    modules?: {
-      specifier?: string;
-      dependencies?: {
-        specifier?: string;
-        code?: { specifier?: string; error?: string };
-      }[];
-    }[];
-  };
-  let root = info.modules?.find(({ specifier }) =>
-    info.roots?.includes(specifier ?? "")
-  );
-  if (!root) {
-    throw new Error(
-      "Unable to inspect browser agent: bundled module not found",
+      `Unable to bundle browser agent:\n${formatBuildError(error)}`,
     );
   }
 
   let unsupported = new Set<string>();
-  for (let dependency of root.dependencies ?? []) {
-    if (dependency.code?.error) {
-      unsupported.add(dependency.specifier ?? "<dynamic import>");
-    } else if (
-      dependency.code?.specifier &&
-      dependency.code.specifier !== "events" &&
-      dependency.code.specifier !== "node:events"
-    ) {
-      unsupported.add(dependency.code.specifier);
+  for (let output of Object.values(result.metafile.outputs)) {
+    for (let imported of output.imports) {
+      if (
+        imported.external && imported.path !== "events" &&
+        imported.path !== "node:events"
+      ) {
+        unsupported.add(imported.path);
+      }
     }
   }
 
@@ -645,53 +589,41 @@ async function bundleDeclarations(
   cwd: string,
   config: string,
 ): Promise<void> {
-  let outputPath = declarationPath.replace(/\.d\.ts$/, ".js");
-  let output = await new Deno.Command(Deno.execPath(), {
-    cwd,
-    args: [
-      "bundle",
-      "--declaration",
-      "--config",
+  void cwd;
+  try {
+    let configFile = ts.readConfigFile(config, ts.sys.readFile);
+    if (configFile.error) {
+      throw new Error(formatTypeScriptDiagnostics([configFile.error]));
+    }
+    let parsed = ts.parseJsonConfigFileContent(
+      configFile.config,
+      ts.sys,
+      dirname(config),
+      undefined,
       config,
-      "--packages=external",
-      "--platform=deno",
-      "--format=esm",
-      "--output",
-      outputPath,
-      entrypoint,
-    ],
-    stdout: "piped",
-    stderr: "piped",
-  }).output();
-
-  if (!output.success) {
-    let message = new TextDecoder().decode(output.stderr).trim();
-    throw new Error(
-      `Unable to generate Interactor declarations${
-        message ? `:\n${message}` : ""
-      }`,
     );
-  }
-}
-
-async function checkDeclarations(
-  path: string,
-  cwd: string,
-  config: string,
-): Promise<void> {
-  let output = await new Deno.Command(Deno.execPath(), {
-    cwd,
-    args: ["check", "--config", config, path],
-    stdout: "piped",
-    stderr: "piped",
-  }).output();
-
-  if (!output.success) {
-    let message = new TextDecoder().decode(output.stderr).trim();
+    if (parsed.errors.length > 0) {
+      throw new Error(formatTypeScriptDiagnostics(parsed.errors));
+    }
+    let program = ts.createProgram([entrypoint], parsed.options);
+    let declarations: string | undefined;
+    let result = program.emit(
+      program.getSourceFile(entrypoint),
+      (path, text) => {
+        if (path.endsWith(".d.ts")) {
+          declarations = text;
+        }
+      },
+      undefined,
+      true,
+    );
+    if (result.emitSkipped || !declarations) {
+      throw new Error(formatTypeScriptDiagnostics(result.diagnostics));
+    }
+    await writeFile(declarationPath, declarations);
+  } catch (error) {
     throw new Error(
-      `Generated Interactor declarations do not type-check${
-        message ? `:\n${message}` : ""
-      }`,
+      `Unable to generate Interactor declarations:\n${formatBuildError(error)}`,
     );
   }
 }
@@ -699,26 +631,85 @@ async function checkDeclarations(
 async function createDeclarationConfig(entrypoint: string): Promise<string> {
   let discovered = await findDenoConfig(dirname(entrypoint));
   let directory = discovered ? dirname(discovered.path) : dirname(entrypoint);
-  let config = discovered?.config ?? {};
-  let compilerOptions = isRecord(config.compilerOptions)
-    ? config.compilerOptions
+  let configDirectory = await mkdtemp(
+    join(directory, ".interactors-declarations-"),
+  );
+  let paths = discovered
+    ? await workspaceTypePaths(
+      discovered.path,
+      discovered.config,
+      configDirectory,
+    )
     : {};
   let scoped = {
-    ...config,
     compilerOptions: {
-      ...compilerOptions,
+      allowImportingTsExtensions: true,
+      declaration: true,
+      emitDeclarationOnly: true,
+      lib: ["ESNext", "DOM", "DOM.Iterable"],
+      module: "ESNext",
+      moduleResolution: "Bundler",
+      noCheck: true,
+      paths,
       skipLibCheck: true,
+      target: "ES2020",
     },
+    files: [entrypoint],
   };
-  let path = join(
-    directory,
-    `.interactors-declarations-${crypto.randomUUID()}.json`,
-  );
+  let path = join(configDirectory, "tsconfig.json");
 
-  await Deno.writeTextFile(path, `${JSON.stringify(scoped, null, 2)}\n`, {
-    createNew: true,
-  });
+  await writeFile(path, `${JSON.stringify(scoped, null, 2)}\n`, { flag: "wx" });
   return path;
+}
+
+async function workspaceTypePaths(
+  configPath: string,
+  config: Record<string, unknown>,
+  configDirectory: string,
+): Promise<Record<string, string[]>> {
+  if (!Array.isArray(config.workspace)) {
+    return {};
+  }
+  let root = dirname(configPath);
+  let paths: Record<string, string[]> = {};
+  for (let member of config.workspace) {
+    if (typeof member !== "string") {
+      continue;
+    }
+    let packageDirectory = resolve(root, member);
+    try {
+      let manifest = parseJsonc(
+        await readFile(join(packageDirectory, "deno.json"), "utf8"),
+      );
+      if (!isRecord(manifest) || typeof manifest.name !== "string") {
+        continue;
+      }
+      let entry = isRecord(manifest.exports) &&
+          typeof manifest.exports["."] === "string"
+        ? manifest.exports["."]
+        : "./mod.ts";
+      let packageLink = join(
+        configDirectory,
+        "node_modules",
+        ...manifest.name.split("/"),
+      );
+      await mkdir(packageLink, { recursive: true });
+      await writeFile(
+        join(packageLink, "package.json"),
+        JSON.stringify({ name: manifest.name, types: "./index.d.ts" }),
+      );
+      await writeFile(
+        join(packageLink, "index.d.ts"),
+        `export * from ${JSON.stringify(resolve(packageDirectory, entry))};\n`,
+      );
+      paths[manifest.name] = [join(packageLink, "index.d.ts")];
+    } catch (error) {
+      if (!isNotFound(error)) {
+        throw error;
+      }
+    }
+  }
+  return paths;
 }
 
 async function findDenoConfig(
@@ -736,7 +727,7 @@ async function findDenoConfig(
     for (let filename of ["deno.json", "deno.jsonc"]) {
       let path = join(directory, filename);
       try {
-        let parsed = parseJsonc(await Deno.readTextFile(path));
+        let parsed = parseJsonc(await readFile(path, "utf8"));
         if (!isRecord(parsed)) {
           throw new Error(`Deno configuration must contain an object: ${path}`);
         }
@@ -746,7 +737,7 @@ async function findDenoConfig(
           return discovered;
         }
       } catch (error) {
-        if (!(error instanceof Deno.errors.NotFound)) {
+        if (!isNotFound(error)) {
           throw error;
         }
       }
@@ -767,24 +758,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 async function finalizeDeclarations(
   path: string,
   registryHash: string,
-  packageMappings: readonly PackageMapping[],
-  importMappings: readonly DeclarationImportMapping[],
-  typeAliases: ReadonlyMap<string, PublicTypeAlias>,
 ): Promise<string> {
-  let declarations = await Deno.readTextFile(path);
-  declarations = declarations.replace(
-    /(["'])(file:[^"']+)\1/g,
-    (original, quote: string, specifier: string) => {
-      let imported = importMappings.find(({ source }) => source === specifier);
-      if (imported) {
-        return `${quote}${imported.target}${quote}`;
-      }
-      let mapping = packageMappings.find(({ root }) =>
-        specifier.startsWith(root)
-      );
-      return mapping ? `${quote}${mapping.name}${quote}` : original;
-    },
-  );
+  let declarations = await readFile(path, "utf8");
 
   let localImport = declarations.match(
     /(?:import\(|from\s+)["'](file:[^"']+|\.{1,2}\/[^"']+)/,
@@ -797,154 +772,25 @@ async function finalizeDeclarations(
     );
   }
 
-  let aliases = [...typeAliases.entries()]
-    .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
-    .map(([name, alias]) =>
-      `export declare const ${name}: typeof import(${
-        JSON.stringify(alias.specifier)
-      })[${JSON.stringify(alias.exportName)}];`
-    )
-    .join("\n");
-  let body = [declarations.trim(), aliases].filter(Boolean).join("\n\n");
-
-  return `// Generated by @interactors/cli. Do not edit.\n// Registry: ${registryHash}\n\n${body}\n`;
+  return `// Generated by @interactors/cli. Do not edit.\n// Registry: ${registryHash}\n\n${declarations.trim()}\n`;
 }
 
-async function discoverDependencies(
-  entrypoint: string,
-): Promise<DependencyMetadata> {
-  let output = await new Deno.Command(Deno.execPath(), {
-    cwd: dirname(entrypoint),
-    args: ["info", "--json", entrypoint],
-    stdout: "piped",
-    stderr: "piped",
-  }).output();
-
-  if (!output.success) {
-    let message = new TextDecoder().decode(output.stderr).trim();
-    throw new Error(
-      `Unable to inspect Interactor dependencies${
-        message ? `:\n${message}` : ""
-      }`,
-    );
-  }
-
-  let info = JSON.parse(new TextDecoder().decode(output.stdout)) as {
-    modules?: {
-      dependencies?: {
-        specifier?: string;
-        code?: { specifier?: string };
-        type?: { specifier?: string };
-      }[];
-    }[];
-  };
-  let mappings = new Map<string, PackageMapping>();
-  let modules = new Map<string, PackageModule>();
-  let imports = new Map<string, DeclarationImportMapping>();
-
-  for (let module of info.modules ?? []) {
-    for (let dependency of module.dependencies ?? []) {
-      let requested = dependency.specifier;
-      let resolved = dependency.code?.specifier ?? dependency.type?.specifier;
-
-      if (
-        !requested || !resolved?.startsWith("file:") ||
-        !isBareSpecifier(requested)
-      ) {
-        continue;
-      }
-
-      let name = packageName(requested);
-      let root = await findPackageRoot(fileURLToPath(resolved), name);
-      if (root) {
-        mappings.set(root, { root, name });
-        imports.set(`${resolved}\0${requested}`, {
-          source: resolved,
-          target: requested,
-        });
-        let code = dependency.code?.specifier;
-        if (code?.startsWith("file:")) {
-          modules.set(`${requested}\0${code}`, {
-            specifier: requested,
-            resolved: code,
-          });
-        }
-      }
-    }
-  }
-
-  return {
-    mappings: [...mappings.values()].sort((left, right) =>
-      right.root.length - left.root.length
-    ),
-    modules: [...modules.values()].sort((left, right) =>
-      left.specifier < right.specifier
-        ? -1
-        : left.specifier > right.specifier
-        ? 1
-        : left.resolved < right.resolved
-        ? -1
-        : left.resolved > right.resolved
-        ? 1
-        : 0
-    ),
-    imports: [...imports.values()].sort((left, right) =>
-      left.source < right.source
-        ? -1
-        : left.source > right.source
-        ? 1
-        : left.target < right.target
-        ? -1
-        : left.target > right.target
-        ? 1
-        : 0
-    ),
-  };
+function isNotFound(error: unknown): boolean {
+  return isRecord(error) && error.code === "ENOENT";
 }
 
-function isBareSpecifier(specifier: string): boolean {
-  return !specifier.startsWith(".") &&
-    !specifier.startsWith("/") &&
-    !/^[a-z][a-z+.-]*:/i.test(specifier);
+function formatBuildError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
-function packageName(specifier: string): string {
-  let [first, second] = specifier.split("/");
-  return first.startsWith("@") ? `${first}/${second}` : first;
-}
-
-async function findPackageRoot(
-  modulePath: string,
-  expectedName: string,
-): Promise<string | undefined> {
-  let directory = dirname(modulePath);
-
-  while (true) {
-    for (let filename of ["deno.json", "package.json"]) {
-      try {
-        let manifest = JSON.parse(
-          await Deno.readTextFile(join(directory, filename)),
-        ) as { name?: string };
-        if (manifest.name === expectedName) {
-          let root = pathToFileURL(`${directory}/`).href;
-          return root.endsWith("/") ? root : `${root}/`;
-        }
-      } catch (error) {
-        if (
-          !(error instanceof Deno.errors.NotFound) &&
-          !(error instanceof SyntaxError)
-        ) {
-          throw error;
-        }
-      }
-    }
-
-    let parent = dirname(directory);
-    if (parent === directory) {
-      return undefined;
-    }
-    directory = parent;
-  }
+function formatTypeScriptDiagnostics(
+  diagnostics: readonly ts.Diagnostic[],
+): string {
+  return ts.formatDiagnostics(diagnostics, {
+    getCanonicalFileName: (path) => path,
+    getCurrentDirectory: ts.sys.getCurrentDirectory,
+    getNewLine: () => "\n",
+  }).trim();
 }
 
 function sortedEntries<T>(value: Record<string, T>): [string, T][] {

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -91,7 +91,10 @@ describe("interactors compile", () => {
   it("rejects malformed commands without compiling", async () => {
     for (
       let [args, message] of [
-        [[], "A command is required"],
+        [
+          [],
+          "interactors does not support EXECUTE\n\nAvailable methods:\n  HELP",
+        ],
         [["unknown"], "unexpected: `unknown`"],
         [["compile"], "entrypoint: must be a non-empty path"],
         [

--- a/packages/cli/test/compile.test.ts
+++ b/packages/cli/test/compile.test.ts
@@ -74,7 +74,12 @@ describe("compile", () => {
       expect(declarations).toContain(`// Registry: ${registry.registryHash}`);
       expect(declarations).toContain("export declare const TextField");
       expect(declarations).toContain("value: string");
-      expect(declarations).toContain('import("@interactors/core")');
+      expect(declarations).toContain(
+        'disabled?: import("@interactors/core").MaybeMatcher<boolean>',
+      );
+      expect(declarations).toContain(
+        'value?: import("@interactors/core").MaybeMatcher<string>',
+      );
       expect(declarations).not.toContain("index.ts");
       expect(declarations).not.toContain("file:");
 
@@ -141,9 +146,10 @@ describe("compile", () => {
               args: [{ $type: "regexp", source: "mail", flags: "i" }],
             },
           }],
-          method: "value",
+          method: "has",
+          args: [{ value: "jonas@example.com" }],
         });
-        expect(valueResult).toEqual({ ok: true, value: "jonas@example.com" });
+        expect(valueResult).toEqual({ ok: true });
 
         let customMatcherResult = await agent.run({
           protocolVersion: AGENT_PROTOCOL_VERSION,
@@ -156,12 +162,10 @@ describe("compile", () => {
               args: ["Other"],
             },
           }],
-          method: "value",
+          method: "has",
+          args: [{ value: "jonas@example.com" }],
         });
-        expect(customMatcherResult).toEqual({
-          ok: true,
-          value: "jonas@example.com",
-        });
+        expect(customMatcherResult).toEqual({ ok: true });
 
         let nestedResult = await agent.run({
           protocolVersion: AGENT_PROTOCOL_VERSION,
@@ -170,12 +174,21 @@ describe("compile", () => {
             { interactor: "Form", locator: "profile" },
             { interactor: "TextField", filters: { disabled: false } },
           ],
+          method: "has",
+          args: [{ value: "jonas@example.com" }],
+        });
+        expect(nestedResult).toEqual({ ok: true });
+
+        let unavailableFilter = await agent.run({
+          protocolVersion: AGENT_PROTOCOL_VERSION,
+          registryHash: registry.registryHash,
+          path: [{ interactor: "TextField", locator: "Email" }],
           method: "value",
         });
-        expect(nestedResult).toEqual({
-          ok: true,
-          value: "jonas@example.com",
-        });
+        expect(unavailableFilter.ok).toBe(false);
+        if (!unavailableFilter.ok) {
+          expect(unavailableFilter.error.name).toBe("NoSuchMethodError");
+        }
 
         let unavailableMethod = await agent.run({
           protocolVersion: AGENT_PROTOCOL_VERSION,
@@ -261,11 +274,10 @@ describe("compile", () => {
       ) as Registry;
       let agentSource = await Deno.readTextFile(result.agentPath);
 
+      expect(declarations).toContain("export declare const Button");
+      expect(declarations).toContain("export declare const TextField");
       expect(declarations).toContain(
-        'typeof import("@interactors/html")["Button"]',
-      );
-      expect(declarations).toContain(
-        'typeof import("@interactors/html")["TextField"]',
+        'value?: import("@interactors/core").MaybeMatcher<string>',
       );
       expect(declarations).not.toContain("file:");
 

--- a/tasks/build-npm.ts
+++ b/tasks/build-npm.ts
@@ -8,6 +8,8 @@ export interface Options {
 }
 
 export async function buildNpm(packageDirectory: string) {
+  packageDirectory = packageDirectory.replace(/^\.\/+/, "").replace(/\/+$/, "");
+
   const { default: denoJson } = await import(
     `../${packageDirectory}/deno.json`,
     {
@@ -110,6 +112,22 @@ export async function buildNpm(packageDirectory: string) {
       new URL(`../${packageDirectory}/README.md`, import.meta.url),
       new URL(`${outDir}/README.md`),
     );
+
+    if (packageDirectory === "packages/cli") {
+      const vendorDirectory = new URL(`${outDir}/vendor/`);
+      await Deno.mkdir(vendorDirectory, { recursive: true });
+      await Promise.all(
+        ["README.md", "configliere.LICENSE.md"].map((filename) =>
+          Deno.copyFile(
+            new URL(
+              `../${packageDirectory}/vendor/${filename}`,
+              import.meta.url,
+            ),
+            new URL(filename, vendorDirectory),
+          )
+        ),
+      );
+    }
   } finally {
     await Deno.remove(tmpImportMapFile);
   }

--- a/tasks/build-npm.ts
+++ b/tasks/build-npm.ts
@@ -26,19 +26,19 @@ export async function buildNpm(packageDirectory: string) {
   const packages = await Promise.all(
     rootDenoJson.workspace.map(
       (packagePath) =>
-        import(`../${packagePath}/deno.json`, { with: { type: "json" } })
-    )
+        import(`../${packagePath}/deno.json`, { with: { type: "json" } }),
+    ),
   );
 
   const workspaceImports = Object.fromEntries(
     packages.map(({ default: pkgDenoJson }) => [
       pkgDenoJson.name,
       `npm:${pkgDenoJson.name}@^${pkgDenoJson.version}`,
-    ])
+    ]),
   );
 
   const tmpImportMapFile = new URL(
-    import.meta.resolve(`../${packageDirectory}/imports-${Date.now()}.json`)
+    import.meta.resolve(`../${packageDirectory}/imports-${Date.now()}.json`),
   );
 
   await Deno.writeTextFile(
@@ -48,17 +48,33 @@ export async function buildNpm(packageDirectory: string) {
         ...denoJson.imports,
         ...workspaceImports,
       },
-    })
+    }),
   );
 
   try {
+    let entryPoints = packageDirectory === "packages/cli"
+      ? [
+        {
+          name: ".",
+          path: `${packageDirectory}/mod.ts`,
+          kind: "export" as const,
+        },
+        {
+          name: "interactors",
+          path: `${packageDirectory}/main.ts`,
+          kind: "bin" as const,
+        },
+      ]
+      : [`${packageDirectory}/mod.ts`];
+
     await build({
       importMap: tmpImportMapFile.toString(),
-      entryPoints: [`${packageDirectory}/mod.ts`],
+      entryPoints,
       outDir: outDir.toString(),
       shims: {
         deno: false,
       },
+      scriptModule: packageDirectory === "packages/cli" ? false : "cjs",
       test: false,
       typeCheck: false,
       compilerOptions: {
@@ -67,27 +83,32 @@ export async function buildNpm(packageDirectory: string) {
         sourceMap: true,
       },
       package: {
-	name: denoJson.name,
-	version: denoJson.version,
-	description: denoJson.description,
-	license: "MIT",
-	homepage: "https://frontside.com/interactors",
-	author: "Frontside Engineering <engineering@frontside.com>",
-	repository: {
-	  type: "git",
-	  url: "git+https://github.com/thefrontside/interactors.git",
-	  directory: packageDirectory,
-	},
-	bugs: {
-	  url: "https://github.com/thefrontside/interactors/issues",
-	},
-	sideEffects: false
+        name: denoJson.name,
+        version: denoJson.version,
+        description: denoJson.description,
+        license: "MIT",
+        homepage: "https://frontside.com/interactors",
+        author: "Frontside Engineering <engineering@frontside.com>",
+        repository: {
+          type: "git",
+          url: "git+https://github.com/thefrontside/interactors.git",
+          directory: packageDirectory,
+        },
+        bugs: {
+          url: "https://github.com/thefrontside/interactors/issues",
+        },
+        dependencies: packageDirectory === "packages/core"
+          ? { "@testing-library/dom": "^8.18.1" }
+          : packageDirectory === "packages/cli"
+          ? { typescript: "^5.9.3" }
+          : undefined,
+        sideEffects: false,
       },
     });
 
     await Deno.copyFile(
       new URL(`../${packageDirectory}/README.md`, import.meta.url),
-      new URL(`${outDir}/README.md`)
+      new URL(`${outDir}/README.md`),
     );
   } finally {
     await Deno.remove(tmpImportMapFile);
@@ -97,7 +118,7 @@ export async function buildNpm(packageDirectory: string) {
 const [packageDirectory] = Deno.args;
 if (!packageDirectory) {
   throw new Error(
-    "a packageDirectory argument is required to build the npm package"
+    "a packageDirectory argument is required to build the npm package",
   );
 }
 


### PR DESCRIPTION
## Motivation

The compiler must not require a Deno installation when distributed through npm. The same JavaScript CLI and compilation pipeline should work when either Node or Deno is the only installed runtime.

## Approach

Publish the CLI as an ESM npm binary and use the Node-compatible process and filesystem APIs that both runtimes implement. Replace the `deno bundle`, `deno info`, and `deno check` subprocesses with the esbuild and TypeScript JavaScript APIs. Runtime metadata produces the registry, while TypeScript declaration emit preserves exact filter, matcher, and action types in the standalone declaration artifact.

Teach the npm build to emit the `interactors` executable and include TypeScript as a runtime dependency. Normalize package paths so release inputs such as `./packages/cli` retain CLI-specific packaging, and include the vendored Configliere provenance and license in the tarball. Use mise and npm trusted publishing in the release workflow. CI builds the npm package, compiles the same entrypoint under Node and Deno, and compares all three output artifacts byte-for-byte.

### Alternate Designs

Shipping a Deno launcher would keep the existing subprocess pipeline but would fail on Node-only systems. Generating declarations from runtime metadata alone would be portable but would erase filter values and action arguments to `unknown`. A separate declaration bundler was evaluated, but its second processing pass broke the package-qualified constructor identities consumed by the Playwright adapter; the TypeScript declaration emitter already produces the required single closed declaration surface.

### Possible Drawbacks or Risks

The CLI npm package includes esbuild and TypeScript as runtime dependencies. The vendored experimental Configliere bundle must be regenerated from its pinned source when upgraded.

The CLI depends on the metadata-enabled Core package introduced earlier in this stack, so Core must be published before each CLI release that requires a new Core version.

### TODOs and Open Questions

None for this stack layer.

## Learning

Deno implements the Node process, filesystem, module, path, and URL APIs needed by the CLI, allowing one implementation for both hosts. Compiler tooling was the only Deno-specific boundary and can run in process through JavaScript APIs.

DNT only emits modules reachable through static imports, so the browser agent source needs a static reference even though the compiler also addresses its emitted file when constructing the generated bundle. Release package paths must also be normalized before package-specific build decisions; Covector paths include a leading `./`.

## Screenshots

Not applicable; this change affects command-line compilation.
